### PR TITLE
Stage 4.3: S3/Minio raw log archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,12 @@ jobs:
 
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/wuhu_test
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_REGION: us-east-1
+      S3_BUCKET: wuhu-raw-logs-ci
+      S3_ACCESS_KEY_ID: minio
+      S3_SECRET_ACCESS_KEY: miniosecret
+      S3_FORCE_PATH_STYLE: "true"
 
     steps:
       - name: Setup repo
@@ -49,6 +55,26 @@ jobs:
         with:
           cache: true
           deno-version: v2.6.8
+
+      - name: Start Minio
+        run: |
+          docker run -d --name wuhu-minio \
+            -p 9000:9000 \
+            -e MINIO_ROOT_USER=minio \
+            -e MINIO_ROOT_PASSWORD=miniosecret \
+            minio/minio:latest server /data --console-address ":9001"
+
+      - name: Wait for Minio
+        run: |
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:9000/minio/health/ready >/dev/null; then
+              echo "minio ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "minio not ready" >&2
+          exit 1
 
       # Core checks
       - name: Check formatting (core)

--- a/core/deno.lock
+++ b/core/deno.lock
@@ -20,6 +20,7 @@
     "npm:@octokit/rest@22": "22.0.1_@octokit+core@7.0.6",
     "npm:drizzle-kit@0.31": "0.31.8_esbuild@0.25.12",
     "npm:drizzle-orm@0.44": "0.44.7_postgres@3.4.8",
+    "npm:minio@8": "8.0.6",
     "npm:postgres@^3.4.5": "3.4.8",
     "npm:redis@^4.7.0": "4.7.1_@redis+client@1.6.1",
     "npm:zod@4.3.6": "4.3.6"
@@ -467,11 +468,58 @@
         "@redis/client"
       ]
     },
+    "@zxing/text-encoding@0.9.0": {
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA=="
+    },
+    "async@3.2.6": {
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
+    },
+    "available-typed-arrays@1.0.7": {
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dependencies": [
+        "possible-typed-array-names"
+      ]
+    },
     "before-after-hook@4.0.0": {
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="
     },
+    "block-stream2@2.1.0": {
+      "integrity": "sha512-suhjmLI57Ewpmq00qaygS8UgEq2ly2PCItenIyhMqVjo4t4pGzqMvfgJuX8iWTeSDdfSSqS6j38fL4ToNL7Pfg==",
+      "dependencies": [
+        "readable-stream"
+      ]
+    },
+    "browser-or-node@2.1.1": {
+      "integrity": "sha512-8CVjaLJGuSKMVTxJ2DpBl5XnlNDiT4cQFeuCJJrvJmts9YrTZDizTX7PjC2s6W4x+MBGZeEY6dGMrF04/6Hgqg=="
+    },
+    "buffer-crc32@1.0.0": {
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w=="
+    },
     "buffer-from@1.1.2": {
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "call-bind-apply-helpers@1.0.2": {
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": [
+        "es-errors",
+        "function-bind"
+      ]
+    },
+    "call-bind@1.0.8": {
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-define-property",
+        "get-intrinsic",
+        "set-function-length"
+      ]
+    },
+    "call-bound@1.0.4": {
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "get-intrinsic"
+      ]
     },
     "cluster-key-slot@1.1.2": {
       "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="
@@ -480,6 +528,17 @@
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dependencies": [
         "ms"
+      ]
+    },
+    "decode-uri-component@0.2.2": {
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="
+    },
+    "define-data-property@1.1.4": {
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dependencies": [
+        "es-define-property",
+        "es-errors",
+        "gopd"
       ]
     },
     "drizzle-kit@0.31.8_esbuild@0.25.12": {
@@ -499,6 +558,26 @@
       ],
       "optionalPeers": [
         "postgres"
+      ]
+    },
+    "dunder-proto@1.0.1": {
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-errors",
+        "gopd"
+      ]
+    },
+    "es-define-property@1.0.1": {
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors@1.3.0": {
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms@1.1.1": {
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": [
+        "es-errors"
       ]
     },
     "esbuild-register@3.6.0_esbuild@0.25.12": {
@@ -570,11 +649,58 @@
       "scripts": true,
       "bin": true
     },
+    "eventemitter3@5.0.4": {
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="
+    },
     "fast-content-type-parse@3.0.0": {
       "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="
     },
+    "fast-xml-parser@4.5.3": {
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+      "dependencies": [
+        "strnum"
+      ],
+      "bin": true
+    },
+    "filter-obj@1.1.0": {
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="
+    },
+    "for-each@0.3.5": {
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dependencies": [
+        "is-callable"
+      ]
+    },
+    "function-bind@1.1.2": {
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "generator-function@2.0.1": {
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="
+    },
     "generic-pool@3.9.0": {
       "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g=="
+    },
+    "get-intrinsic@1.3.0": {
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-define-property",
+        "es-errors",
+        "es-object-atoms",
+        "function-bind",
+        "get-proto",
+        "gopd",
+        "has-symbols",
+        "hasown",
+        "math-intrinsics"
+      ]
+    },
+    "get-proto@1.0.1": {
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": [
+        "dunder-proto",
+        "es-object-atoms"
+      ]
     },
     "get-tsconfig@4.13.1": {
       "integrity": "sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w==",
@@ -582,11 +708,130 @@
         "resolve-pkg-maps"
       ]
     },
+    "gopd@1.2.0": {
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
+    "has-property-descriptors@1.0.2": {
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dependencies": [
+        "es-define-property"
+      ]
+    },
+    "has-symbols@1.1.0": {
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "has-tostringtag@1.0.2": {
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": [
+        "has-symbols"
+      ]
+    },
+    "hasown@2.0.2": {
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": [
+        "function-bind"
+      ]
+    },
+    "inherits@2.0.4": {
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ipaddr.js@2.3.0": {
+      "integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg=="
+    },
+    "is-arguments@1.2.0": {
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dependencies": [
+        "call-bound",
+        "has-tostringtag"
+      ]
+    },
+    "is-callable@1.2.7": {
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
+    },
+    "is-generator-function@1.1.2": {
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dependencies": [
+        "call-bound",
+        "generator-function",
+        "get-proto",
+        "has-tostringtag",
+        "safe-regex-test"
+      ]
+    },
+    "is-regex@1.2.1": {
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dependencies": [
+        "call-bound",
+        "gopd",
+        "has-tostringtag",
+        "hasown"
+      ]
+    },
+    "is-typed-array@1.1.15": {
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dependencies": [
+        "which-typed-array"
+      ]
+    },
+    "lodash@4.17.23": {
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
+    },
+    "math-intrinsics@1.1.0": {
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "mime-db@1.52.0": {
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types@2.1.35": {
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": [
+        "mime-db"
+      ]
+    },
+    "minio@8.0.6": {
+      "integrity": "sha512-sOeh2/b/XprRmEtYsnNRFtOqNRTPDvYtMWh+spWlfsuCV/+IdxNeKVUMKLqI7b5Dr07ZqCPuaRGU/rB9pZYVdQ==",
+      "dependencies": [
+        "async",
+        "block-stream2",
+        "browser-or-node",
+        "buffer-crc32",
+        "eventemitter3",
+        "fast-xml-parser",
+        "ipaddr.js",
+        "lodash",
+        "mime-types",
+        "query-string",
+        "stream-json",
+        "through2",
+        "web-encoding",
+        "xml2js"
+      ]
+    },
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "possible-typed-array-names@1.1.0": {
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="
+    },
     "postgres@3.4.8": {
       "integrity": "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg=="
+    },
+    "query-string@7.1.3": {
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+      "dependencies": [
+        "decode-uri-component",
+        "filter-obj",
+        "split-on-first",
+        "strict-uri-encode"
+      ]
+    },
+    "readable-stream@3.6.2": {
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": [
+        "inherits",
+        "string_decoder",
+        "util-deprecate"
+      ]
     },
     "redis@4.7.1_@redis+client@1.6.1": {
       "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
@@ -602,6 +847,31 @@
     "resolve-pkg-maps@1.0.0": {
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="
     },
+    "safe-buffer@5.2.1": {
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safe-regex-test@1.1.0": {
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "is-regex"
+      ]
+    },
+    "sax@1.4.4": {
+      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw=="
+    },
+    "set-function-length@1.2.2": {
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dependencies": [
+        "define-data-property",
+        "es-errors",
+        "function-bind",
+        "get-intrinsic",
+        "gopd",
+        "has-property-descriptors"
+      ]
+    },
     "source-map-support@0.5.21": {
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dependencies": [
@@ -612,8 +882,82 @@
     "source-map@0.6.1": {
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
+    "split-on-first@1.1.0": {
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
+    "stream-chain@2.2.5": {
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA=="
+    },
+    "stream-json@1.9.1": {
+      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "dependencies": [
+        "stream-chain"
+      ]
+    },
+    "strict-uri-encode@2.0.0": {
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="
+    },
+    "string_decoder@1.3.0": {
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": [
+        "safe-buffer"
+      ]
+    },
+    "strnum@1.1.2": {
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA=="
+    },
+    "through2@4.0.2": {
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "dependencies": [
+        "readable-stream"
+      ]
+    },
     "universal-user-agent@7.0.3": {
       "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="
+    },
+    "util-deprecate@1.0.2": {
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "util@0.12.5": {
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dependencies": [
+        "inherits",
+        "is-arguments",
+        "is-generator-function",
+        "is-typed-array",
+        "which-typed-array"
+      ]
+    },
+    "web-encoding@1.1.5": {
+      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+      "dependencies": [
+        "util"
+      ],
+      "optionalDependencies": [
+        "@zxing/text-encoding"
+      ]
+    },
+    "which-typed-array@1.1.20": {
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dependencies": [
+        "available-typed-arrays",
+        "call-bind",
+        "call-bound",
+        "for-each",
+        "get-proto",
+        "gopd",
+        "has-tostringtag"
+      ]
+    },
+    "xml2js@0.6.2": {
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dependencies": [
+        "sax",
+        "xmlbuilder"
+      ]
+    },
+    "xmlbuilder@11.0.1": {
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "yallist@4.0.0": {
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
@@ -652,6 +996,7 @@
           "jsr:@std/yaml@1",
           "npm:@octokit/rest@22",
           "npm:drizzle-orm@0.44",
+          "npm:minio@8",
           "npm:postgres@^3.4.5",
           "npm:redis@^4.7.0"
         ]

--- a/core/packages/server/deno.json
+++ b/core/packages/server/deno.json
@@ -11,6 +11,7 @@
     "@std/path": "jsr:@std/path@^1",
     "@std/yaml": "jsr:@std/yaml@^1",
     "@octokit/rest": "npm:@octokit/rest@^22.0.0",
+    "minio": "npm:minio@^8.0.0",
     "redis": "npm:redis@^4.7.0",
     "drizzle-orm": "npm:drizzle-orm@^0.44.0",
     "drizzle-orm/postgres-js": "npm:drizzle-orm@^0.44.0/postgres-js",

--- a/core/packages/server/src/raw-logs-integration_test.ts
+++ b/core/packages/server/src/raw-logs-integration_test.ts
@@ -1,0 +1,143 @@
+import { assert, assertEquals } from '@std/assert'
+import { Hono } from '@hono/hono'
+
+import { FakeAgentProvider } from '../../sandbox-daemon/src/agent-provider.ts'
+import { createSandboxDaemonApp } from '../../sandbox-daemon/src/server.ts'
+import type { SandboxDaemonAgentEvent } from '../../sandbox-daemon/src/types.ts'
+
+import type { S3RawLogsConfig } from './config.ts'
+import { RawLogsS3Store } from './raw-logs-s3.ts'
+
+async function waitFor(
+  predicate: () => Promise<boolean>,
+  timeoutMs = 5000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await predicate()) return
+    await new Promise((r) => setTimeout(r, 25))
+  }
+  throw new Error('timed_out')
+}
+
+function loadS3TestConfig(): S3RawLogsConfig | null {
+  const endpoint = (Deno.env.get('S3_ENDPOINT') ?? '').trim()
+  const bucket = (Deno.env.get('S3_BUCKET') ?? '').trim()
+  const accessKeyId = (Deno.env.get('S3_ACCESS_KEY_ID') ?? '').trim()
+  const secretAccessKey = (Deno.env.get('S3_SECRET_ACCESS_KEY') ?? '').trim()
+  const region = (Deno.env.get('S3_REGION') ?? 'us-east-1').trim() ||
+    'us-east-1'
+  if (!endpoint || !bucket || !accessKeyId || !secretAccessKey) return null
+  return {
+    endpoint,
+    bucket,
+    accessKeyId,
+    secretAccessKey,
+    region,
+    forcePathStyle: true,
+    presignExpiresInSeconds: 60,
+  }
+}
+
+function agentEvent(payload: Record<string, unknown>): SandboxDaemonAgentEvent {
+  const type = typeof payload.type === 'string' ? payload.type : 'unknown'
+  return {
+    source: 'agent',
+    type,
+    timestamp: Date.now(),
+    payload: { ...payload, type },
+  }
+}
+
+Deno.test({
+  name: 'integration: daemon uploads raw logs to S3 after turn',
+  ignore: !loadS3TestConfig(),
+  fn: async () => {
+    const s3 = loadS3TestConfig()
+    if (!s3) return
+
+    const store = new RawLogsS3Store(s3)
+    const sandboxId = `sb_int_${crypto.randomUUID().slice(0, 10)}`
+
+    const coreApp = new Hono()
+    coreApp.post('/sandboxes/:id/state', (c) => c.json({ ok: true }))
+    coreApp.post('/sandboxes/:id/logs', async (c) => {
+      const id = c.req.param('id')
+      const turnIndexRaw = c.req.query('turnIndex')
+      const parsedTurnIndex = turnIndexRaw ? Number(turnIndexRaw) : NaN
+      const turnIndex = Number.isFinite(parsedTurnIndex)
+        ? Math.floor(parsedTurnIndex)
+        : NaN
+      if (!Number.isInteger(turnIndex) || turnIndex < 0) {
+        return c.json({ error: 'invalid_turn_index' }, 400)
+      }
+      if (!c.req.raw.body) return c.json({ error: 'missing_body' }, 400)
+      await store.uploadTurn(id, turnIndex, c.req.raw.body)
+      return c.json({ ok: true })
+    })
+
+    const fetchFn: typeof fetch = async (input, init) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : input.url
+      const parsed = new URL(url)
+      const req = new Request(
+        `http://core.test${parsed.pathname}${parsed.search}`,
+        init,
+      )
+      return await coreApp.fetch(req)
+    }
+
+    const provider = new FakeAgentProvider()
+    const tmp = await Deno.makeTempDir()
+    const { app } = createSandboxDaemonApp({
+      provider,
+      workspaceRoot: tmp,
+      statePersistence: {
+        cursorPath: `${tmp}/cursor.json`,
+        fetchFn,
+        baseDelayMs: 1,
+        sleep: async () => {},
+      },
+    })
+
+    const initRes = await app.request('/init', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        sandboxId,
+        coreApiUrl: 'http://core.local',
+        workspace: { repos: [] },
+      }),
+    })
+    assertEquals(initRes.status, 200)
+
+    provider.emit(agentEvent({ type: 'turn_start', timestamp: 1 }))
+    provider.emit(
+      agentEvent({
+        type: 'message_end',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'hi' }],
+          timestamp: 2,
+        },
+      }),
+    )
+    provider.emit(agentEvent({ type: 'turn_end', timestamp: 3 }))
+
+    await waitFor(() => store.existsTurn(sandboxId, 1))
+
+    const { url } = await store.presignGetTurn(sandboxId, 1, 60)
+    const res = await fetch(url)
+    assertEquals(res.status, 200)
+    const text = await res.text()
+    const lines = text.trimEnd().split('\n').map((line) =>
+      JSON.parse(line) as { type: string }
+    )
+    assert(lines.length >= 2)
+    assertEquals(lines[0]?.type, 'turn_start')
+    assertEquals(lines.at(-1)?.type, 'turn_end')
+  },
+})

--- a/core/packages/server/src/raw-logs-s3.ts
+++ b/core/packages/server/src/raw-logs-s3.ts
@@ -1,0 +1,114 @@
+import { Client as MinioClient } from 'minio'
+import { Readable } from 'node:stream'
+import type { ReadableStream as NodeReadableStream } from 'node:stream/web'
+
+import type { S3RawLogsConfig } from './config.ts'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isNotFoundError(error: unknown): boolean {
+  if (!isRecord(error)) return false
+  const code = typeof error.code === 'string' ? error.code : ''
+  const name = typeof error.name === 'string' ? error.name : ''
+  return code === 'NoSuchKey' || code === 'NotFound' || name === 'NotFound'
+}
+
+export interface PresignedRawLogUrl {
+  url: string
+  expiresIn: number
+}
+
+export class RawLogsS3Store {
+  #client: MinioClient
+  #bucket: string
+  #region: string
+  #presignDefaultExpiresInSeconds: number
+  #bucketReady: Promise<void> | null = null
+
+  constructor(config: S3RawLogsConfig) {
+    const endpoint = new URL(config.endpoint)
+    const useSSL = endpoint.protocol === 'https:'
+    const port = endpoint.port ? Number(endpoint.port) : (useSSL ? 443 : 80)
+
+    this.#bucket = config.bucket
+    this.#region = config.region
+    this.#presignDefaultExpiresInSeconds = config.presignExpiresInSeconds
+    this.#client = new MinioClient({
+      endPoint: endpoint.hostname,
+      port,
+      useSSL,
+      accessKey: config.accessKeyId,
+      secretKey: config.secretAccessKey,
+      region: config.region,
+    })
+  }
+
+  keyForTurn(sessionId: string, turnIndex: number): string {
+    const turn = Math.max(0, Math.floor(turnIndex))
+    return `sessions/${sessionId}/turn-${turn}.jsonl`
+  }
+
+  async ensureBucket(): Promise<void> {
+    if (this.#bucketReady) return await this.#bucketReady
+    this.#bucketReady = (async () => {
+      const exists = await this.#client.bucketExists(this.#bucket)
+      if (exists) return
+      await this.#client.makeBucket(this.#bucket, this.#region).catch((err) => {
+        // Best-effort: if another replica races us, ignore bucket-exists errors.
+        if (isRecord(err) && typeof err.code === 'string') {
+          if (err.code === 'BucketAlreadyOwnedByYou') return
+          if (err.code === 'BucketAlreadyExists') return
+        }
+        throw err
+      })
+    })()
+    return await this.#bucketReady
+  }
+
+  async uploadTurn(
+    sessionId: string,
+    turnIndex: number,
+    body: ReadableStream<Uint8Array>,
+    contentType = 'application/x-ndjson',
+  ): Promise<{ bucket: string; key: string }> {
+    await this.ensureBucket()
+    const key = this.keyForTurn(sessionId, turnIndex)
+    const stream = Readable.fromWeb(body as unknown as NodeReadableStream)
+    await this.#client.putObject(this.#bucket, key, stream, undefined, {
+      'Content-Type': contentType,
+    })
+    return { bucket: this.#bucket, key }
+  }
+
+  async existsTurn(sessionId: string, turnIndex: number): Promise<boolean> {
+    await this.ensureBucket()
+    const key = this.keyForTurn(sessionId, turnIndex)
+    try {
+      await this.#client.statObject(this.#bucket, key)
+      return true
+    } catch (err) {
+      if (isNotFoundError(err)) return false
+      throw err
+    }
+  }
+
+  async presignGetTurn(
+    sessionId: string,
+    turnIndex: number,
+    expiresInSeconds?: number,
+  ): Promise<PresignedRawLogUrl> {
+    await this.ensureBucket()
+    const key = this.keyForTurn(sessionId, turnIndex)
+    const expiresIn = Number.isFinite(expiresInSeconds)
+      ? Math.max(1, Math.min(86_400, Math.floor(expiresInSeconds!)))
+      : this.#presignDefaultExpiresInSeconds
+    const url = await this.#client.presignedGetObject(
+      this.#bucket,
+      key,
+      expiresIn,
+    )
+    return { url, expiresIn }
+  }
+}

--- a/core/packages/server/src/raw-logs-s3_test.ts
+++ b/core/packages/server/src/raw-logs-s3_test.ts
@@ -1,0 +1,68 @@
+import { assert, assertEquals } from '@std/assert'
+
+import type { S3RawLogsConfig } from './config.ts'
+import { RawLogsS3Store } from './raw-logs-s3.ts'
+
+function loadS3TestConfig(): S3RawLogsConfig | null {
+  const endpoint = (Deno.env.get('S3_ENDPOINT') ?? '').trim()
+  const bucket = (Deno.env.get('S3_BUCKET') ?? '').trim()
+  const accessKeyId = (Deno.env.get('S3_ACCESS_KEY_ID') ?? '').trim()
+  const secretAccessKey = (Deno.env.get('S3_SECRET_ACCESS_KEY') ?? '').trim()
+  const region = (Deno.env.get('S3_REGION') ?? 'us-east-1').trim() ||
+    'us-east-1'
+  if (!endpoint || !bucket || !accessKeyId || !secretAccessKey) return null
+  return {
+    endpoint,
+    bucket,
+    accessKeyId,
+    secretAccessKey,
+    region,
+    forcePathStyle: true,
+    presignExpiresInSeconds: 60,
+  }
+}
+
+Deno.test('RawLogsS3Store keyForTurn matches spec', () => {
+  const store = new RawLogsS3Store({
+    endpoint: 'http://localhost:9000',
+    region: 'us-east-1',
+    bucket: 'wuhu-raw-logs',
+    accessKeyId: 'minio',
+    secretAccessKey: 'miniosecret',
+    forcePathStyle: true,
+    presignExpiresInSeconds: 60,
+  })
+  assertEquals(store.keyForTurn('sb_123', 0), 'sessions/sb_123/turn-0.jsonl')
+  assertEquals(store.keyForTurn('sb_123', 2), 'sessions/sb_123/turn-2.jsonl')
+})
+
+Deno.test({
+  name: 'RawLogsS3Store uploads + presigns + downloads',
+  ignore: !loadS3TestConfig(),
+  fn: async () => {
+    const cfg = loadS3TestConfig()
+    if (!cfg) return
+    const store = new RawLogsS3Store(cfg)
+
+    const sessionId = `sb_s3_${crypto.randomUUID().slice(0, 8)}`
+    const turnIndex = 1
+    const ndjson =
+      '{"type":"turn_start","timestamp":1}\n{"type":"turn_end","timestamp":2}\n'
+    const encoder = new TextEncoder()
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(ndjson))
+        controller.close()
+      },
+    })
+
+    await store.uploadTurn(sessionId, turnIndex, body)
+    assert(await store.existsTurn(sessionId, turnIndex))
+
+    const { url } = await store.presignGetTurn(sessionId, turnIndex, 60)
+    const res = await fetch(url)
+    assertEquals(res.status, 200)
+    const text = await res.text()
+    assertEquals(text, ndjson)
+  },
+})

--- a/deploy/core.yaml
+++ b/deploy/core.yaml
@@ -49,6 +49,24 @@ spec:
               value: "paideia-ai,wuhu-labs"
             - name: REDIS_URL
               value: "redis://redis:6379"
+            - name: S3_ENDPOINT
+              value: "http://minio:9000"
+            - name: S3_REGION
+              value: "us-east-1"
+            - name: S3_BUCKET
+              value: "wuhu-raw-logs"
+            - name: S3_FORCE_PATH_STYLE
+              value: "true"
+            - name: S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: minio-credentials
+                  key: root-user
+            - name: S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: minio-credentials
+                  key: root-password
             - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Implements Stage 4.3 raw Pi session log archiving to in-cluster MinIO.

- Core: `POST /sandboxes/:id/logs?turnIndex=N` streams NDJSON to MinIO bucket `wuhu-raw-logs`; `GET /sandboxes/:id/logs/:turnIndex` returns a presigned download URL.
- Daemon: after each turn, posts raw NDJSON events to Core after state persistence succeeds (best-effort).
- Tests: unit + integration coverage, with MinIO started in CI.