### PR TITLE
Migrate PiAI HTTP transport to AsyncHTTPClient

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,10 +23,14 @@ let package = Package(
     .package(url: "https://github.com/nicklockwood/SwiftFormat.git", from: "0.59.1"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
     .package(url: "https://github.com/swiftlang/swift-testing.git", from: "6.2.0"),
+    .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.27.0"),
   ],
   targets: [
     .target(
       name: "PiAI",
+      dependencies: [
+        .product(name: "AsyncHTTPClient", package: "async-http-client"),
+      ],
       swiftSettings: strictConcurrency,
     ),
     .executableTarget(

--- a/Sources/wuhu/main.swift
+++ b/Sources/wuhu/main.swift
@@ -1,8 +1,5 @@
 import ArgumentParser
 import Foundation
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
-#endif
 import PiAI
 
 @main

--- a/Tests/PiAITests/AnthropicMessagesProviderTests.swift
+++ b/Tests/PiAITests/AnthropicMessagesProviderTests.swift
@@ -1,7 +1,4 @@
 import Foundation
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
-#endif
 import PiAI
 import Testing
 
@@ -10,7 +7,7 @@ struct AnthropicMessagesProviderTests {
     let apiKey = "ak-test"
 
     let http = MockHTTPClient(sseHandler: { request in
-      #expect(request.url?.absoluteString == "https://api.anthropic.com/v1/messages")
+      #expect(request.url.absoluteString == "https://api.anthropic.com/v1/messages")
       let headers = normalizedHeaders(request)
       #expect(headers["x-api-key"] == apiKey)
       #expect(headers["accept"] == "text/event-stream")
@@ -41,9 +38,9 @@ struct AnthropicMessagesProviderTests {
   }
 }
 
-private func normalizedHeaders(_ request: URLRequest) -> [String: String] {
+private func normalizedHeaders(_ request: HTTPRequest) -> [String: String] {
   Dictionary(
-    uniqueKeysWithValues: (request.allHTTPHeaderFields ?? [:]).map { key, value in
+    uniqueKeysWithValues: request.headers.map { key, value in
       (key.lowercased(), value)
     },
   )

--- a/Tests/PiAITests/LiveProvidersE2ETests.swift
+++ b/Tests/PiAITests/LiveProvidersE2ETests.swift
@@ -1,7 +1,4 @@
 import Foundation
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
-#endif
 import PiAI
 import Testing
 

--- a/Tests/PiAITests/MockHTTPClient.swift
+++ b/Tests/PiAITests/MockHTTPClient.swift
@@ -1,21 +1,18 @@
 import Foundation
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
-#endif
 import PiAI
 
 struct MockHTTPClient: HTTPClient {
-  var dataHandler: (@Sendable (URLRequest) async throws -> (Data, HTTPURLResponse))?
-  var sseHandler: (@Sendable (URLRequest) async throws -> AsyncThrowingStream<SSEMessage, any Error>)?
+  var dataHandler: (@Sendable (HTTPRequest) async throws -> (Data, HTTPResponse))?
+  var sseHandler: (@Sendable (HTTPRequest) async throws -> AsyncThrowingStream<SSEMessage, any Error>)?
 
-  func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+  func data(for request: HTTPRequest) async throws -> (Data, HTTPResponse) {
     guard let dataHandler else {
       throw PiAIError.unsupported("MockHTTPClient.dataHandler not set")
     }
     return try await dataHandler(request)
   }
 
-  func sse(for request: URLRequest) async throws -> AsyncThrowingStream<SSEMessage, any Error> {
+  func sse(for request: HTTPRequest) async throws -> AsyncThrowingStream<SSEMessage, any Error> {
     guard let sseHandler else {
       throw PiAIError.unsupported("MockHTTPClient.sseHandler not set")
     }

--- a/Tests/PiAITests/OpenAICodexResponsesProviderTests.swift
+++ b/Tests/PiAITests/OpenAICodexResponsesProviderTests.swift
@@ -1,7 +1,4 @@
 import Foundation
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
-#endif
 import PiAI
 import Testing
 
@@ -10,7 +7,7 @@ struct OpenAICodexResponsesProviderTests {
     let token = makeTestJWT(accountId: "acc_test")
 
     let http = MockHTTPClient(sseHandler: { request in
-      #expect(request.url?.absoluteString == "https://chatgpt.com/backend-api/codex/responses")
+      #expect(request.url.absoluteString == "https://chatgpt.com/backend-api/codex/responses")
       let headers = normalizedHeaders(request)
       #expect(headers["authorization"] == "Bearer \(token)")
       #expect(headers["chatgpt-account-id"] == "acc_test")
@@ -65,7 +62,7 @@ struct OpenAICodexResponsesProviderTests {
       #expect(headers["conversation_id"] == sessionId)
       #expect(headers["session_id"] == sessionId)
 
-      let body = try #require(request.httpBody)
+      let body = try #require(request.body)
       let json = try JSONSerialization.jsonObject(with: body) as? [String: Any]
       let promptCacheKey = json?["prompt_cache_key"] as? String
       let retention = json?["prompt_cache_retention"] as? String
@@ -105,9 +102,9 @@ private func base64URL(_ data: Data) -> String {
     .replacingOccurrences(of: "=", with: "")
 }
 
-private func normalizedHeaders(_ request: URLRequest) -> [String: String] {
+private func normalizedHeaders(_ request: HTTPRequest) -> [String: String] {
   Dictionary(
-    uniqueKeysWithValues: (request.allHTTPHeaderFields ?? [:]).map { key, value in
+    uniqueKeysWithValues: request.headers.map { key, value in
       (key.lowercased(), value)
     },
   )

--- a/Tests/PiAITests/OpenAIResponsesProviderTests.swift
+++ b/Tests/PiAITests/OpenAIResponsesProviderTests.swift
@@ -1,7 +1,4 @@
 import Foundation
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
-#endif
 import PiAI
 import Testing
 
@@ -10,8 +7,8 @@ struct OpenAIResponsesProviderTests {
     let apiKey = "sk-test"
 
     let http = MockHTTPClient(sseHandler: { request in
-      #expect(request.url?.absoluteString == "https://api.openai.com/v1/responses")
-      let headers = request.allHTTPHeaderFields ?? [:]
+      #expect(request.url.absoluteString == "https://api.openai.com/v1/responses")
+      let headers = request.headers
       #expect(headers["Authorization"] == "Bearer \(apiKey)")
       #expect(headers["Accept"] == "text/event-stream")
 


### PR DESCRIPTION
## Summary
- replace the URLSession-based PiAI transport with an AsyncHTTPClient-backed transport
- remove FoundationNetworking/URLRequest/HTTPURLResponse usage from providers and tests
- introduce PiAI HTTPRequest/HTTPResponse models and update provider test mocks accordingly

## Verification
- swift build --build-tests
- swift package --allow-writing-to-package-directory swiftformat --lint .
- swift test --skip-build