### PR TITLE
Port PiAgent to Swift + add agent demo CLI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
   ],
   products: [
     .library(name: "PiAI", targets: ["PiAI"]),
+    .library(name: "PiAgent", targets: ["PiAgent"]),
     .executable(name: "wuhu", targets: ["wuhu"]),
   ],
   dependencies: [
@@ -40,10 +41,18 @@ let package = Package(
       ],
       swiftSettings: strictConcurrency,
     ),
+    .target(
+      name: "PiAgent",
+      dependencies: [
+        "PiAI",
+      ],
+      swiftSettings: strictConcurrency,
+    ),
     .executableTarget(
       name: "wuhu",
       dependencies: [
         "PiAI",
+        "PiAgent",
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
         .product(name: "GRDB", package: "GRDB.swift"),
       ],
@@ -53,6 +62,14 @@ let package = Package(
       name: "PiAITests",
       dependencies: [
         "PiAI",
+        .product(name: "Testing", package: "swift-testing"),
+      ],
+      swiftSettings: strictConcurrency,
+    ),
+    .testTarget(
+      name: "PiAgentTests",
+      dependencies: [
+        "PiAgent",
         .product(name: "Testing", package: "swift-testing"),
       ],
       swiftSettings: strictConcurrency,

--- a/Sources/PiAI/Internal/ProviderHelpers.swift
+++ b/Sources/PiAI/Internal/ProviderHelpers.swift
@@ -13,11 +13,13 @@ func parseJSON(_ text: String) throws -> [String: Any]? {
 }
 
 func applyTextDelta(_ delta: String, to message: inout AssistantMessage) {
-  switch message.content.first {
-  case var .text(part):
-    part.text += delta
-    message.content = [.text(part)]
-  default:
-    message.content = [.text(.init(text: delta))]
+  for i in message.content.indices {
+    if case var .text(part) = message.content[i] {
+      part.text += delta
+      message.content[i] = .text(part)
+      return
+    }
   }
+
+  message.content.append(.text(.init(text: delta)))
 }

--- a/Sources/PiAI/Providers/AnthropicMessagesProvider.swift
+++ b/Sources/PiAI/Providers/AnthropicMessagesProvider.swift
@@ -7,6 +7,30 @@ public struct AnthropicMessagesProvider: Sendable {
     self.http = http
   }
 
+  public func stream(model: Model, context: SimpleContext, options: RequestOptions = .init()) async throws
+    -> AsyncThrowingStream<AssistantMessageEvent, any Error>
+  {
+    guard model.provider == .anthropic else { throw PiAIError.unsupported("Expected provider anthropic") }
+
+    let apiKey = try resolveAPIKey(options.apiKey, env: "ANTHROPIC_API_KEY", provider: model.provider)
+    let url = model.baseURL.appending(path: "messages")
+
+    var request = HTTPRequest(url: url, method: "POST")
+    request.setHeader(apiKey, for: "x-api-key")
+    request.setHeader("application/json", for: "Content-Type")
+    request.setHeader("text/event-stream", for: "Accept")
+    request.setHeader("2023-06-01", for: "anthropic-version")
+    for (k, v) in options.headers {
+      request.setHeader(v, for: k)
+    }
+
+    let body = try JSONSerialization.data(withJSONObject: buildBody(model: model, context: context, options: options))
+    request.body = body
+
+    let sse = try await http.sse(for: request)
+    return mapAnthropicSSE(sse, provider: model.provider, modelId: model.id)
+  }
+
   public func stream(model: Model, context: Context, options: RequestOptions = .init()) async throws
     -> AsyncThrowingStream<AssistantMessageEvent, any Error>
   {
@@ -29,6 +53,81 @@ public struct AnthropicMessagesProvider: Sendable {
 
     let sse = try await http.sse(for: request)
     return mapAnthropicSSE(sse, provider: model.provider, modelId: model.id)
+  }
+
+  private func buildBody(model: Model, context: SimpleContext, options: RequestOptions) -> [String: Any] {
+    var messages: [[String: Any]] = []
+
+    for message in context.messages {
+      switch message {
+      case let .user(user):
+        messages.append([
+          "role": "user",
+          "content": user.content,
+        ])
+
+      case let .assistant(assistant):
+        var blocks: [[String: Any]] = []
+        for part in assistant.content {
+          switch part {
+          case let .text(text):
+            blocks.append(["type": "text", "text": text.text])
+          case let .toolCall(call):
+            blocks.append([
+              "type": "tool_use",
+              "id": call.id,
+              "name": call.name,
+              "input": call.arguments.toAny(),
+            ])
+          }
+        }
+        if !blocks.isEmpty {
+          messages.append([
+            "role": "assistant",
+            "content": blocks,
+          ])
+        }
+
+      case let .toolResult(result):
+        let contentText = result.content
+        messages.append([
+          "role": "user",
+          "content": [
+            [
+              "type": "tool_result",
+              "tool_use_id": result.toolCallId,
+              "content": contentText,
+              "is_error": result.isError,
+            ],
+          ],
+        ])
+      }
+    }
+
+    var body: [String: Any] = [
+      "model": model.id,
+      "stream": true,
+      "messages": messages,
+      "max_tokens": options.maxTokens ?? 1024,
+    ]
+
+    if let system = context.systemPrompt, !system.isEmpty {
+      body["system"] = system
+    }
+    if let temperature = options.temperature {
+      body["temperature"] = temperature
+    }
+    if let tools = context.tools, !tools.isEmpty {
+      body["tools"] = tools.map { tool in
+        [
+          "name": tool.name,
+          "description": tool.description,
+          "input_schema": tool.parameters.toAny(),
+        ]
+      }
+    }
+
+    return body
   }
 
   private func buildBody(model: Model, context: Context, options: RequestOptions) -> [String: Any] {
@@ -67,23 +166,105 @@ public struct AnthropicMessagesProvider: Sendable {
         var output = AssistantMessage(provider: provider, model: modelId)
         continuation.yield(.start(partial: output))
 
+        struct Block {
+          var type: String
+          var text: String
+          var toolCallId: String
+          var toolName: String
+          var initialArguments: JSONValue?
+          var partialJSON: String
+        }
+        var blocksByIndex: [Int: Block] = [:]
+
         do {
           for try await message in sse {
             guard let event = message.event else { continue }
             guard let dict = try parseJSON(message.data) else { continue }
 
             switch event {
+            case "content_block_start":
+              guard let index = dict["index"] as? Int,
+                    let contentBlock = dict["content_block"] as? [String: Any],
+                    let blockType = contentBlock["type"] as? String
+              else { continue }
+
+              if blockType == "text" {
+                blocksByIndex[index] = .init(
+                  type: "text",
+                  text: "",
+                  toolCallId: "",
+                  toolName: "",
+                  initialArguments: nil,
+                  partialJSON: "",
+                )
+              } else if blockType == "tool_use" {
+                let id = contentBlock["id"] as? String ?? ""
+                let name = contentBlock["name"] as? String ?? ""
+                let initialArgs: JSONValue? = {
+                  guard let input = contentBlock["input"] else { return nil }
+                  return try? JSONValue(input)
+                }()
+                blocksByIndex[index] = .init(
+                  type: "tool_use",
+                  text: "",
+                  toolCallId: id,
+                  toolName: name,
+                  initialArguments: initialArgs,
+                  partialJSON: "",
+                )
+              }
+
             case "content_block_delta":
-              if let delta = dict["delta"] as? [String: Any],
-                 (delta["type"] as? String) == "text_delta",
-                 let text = delta["text"] as? String
-              {
+              let index = dict["index"] as? Int ?? 0
+              guard let delta = dict["delta"] as? [String: Any],
+                    let deltaType = delta["type"] as? String
+              else { continue }
+
+              if deltaType == "text_delta", let text = delta["text"] as? String {
                 applyTextDelta(text, to: &output)
                 continuation.yield(.textDelta(delta: text, partial: output))
+                if var b = blocksByIndex[index] {
+                  b.text += text
+                  blocksByIndex[index] = b
+                }
+              } else if deltaType == "input_json_delta", let partial = delta["partial_json"] as? String {
+                if var b = blocksByIndex[index] {
+                  b.partialJSON += partial
+                  blocksByIndex[index] = b
+                }
+              }
+
+            case "content_block_stop":
+              guard let index = dict["index"] as? Int,
+                    let b = blocksByIndex[index]
+              else { continue }
+              if b.type == "tool_use" {
+                let args: JSONValue = {
+                  if !b.partialJSON.isEmpty,
+                     let any = try? JSONSerialization.jsonObject(with: Data(b.partialJSON.utf8)),
+                     let v = try? JSONValue(any)
+                  {
+                    return v
+                  }
+                  return b.initialArguments ?? .object([:])
+                }()
+                output.content.append(.toolCall(.init(id: b.toolCallId, name: b.toolName, arguments: args)))
+              }
+
+            case "message_delta":
+              if let delta = dict["delta"] as? [String: Any],
+                 let stop = delta["stop_reason"] as? String
+              {
+                output.stopReason = mapAnthropicStopReason(stop)
               }
 
             case "message_stop":
-              output.stopReason = .stop
+              // stopReason already set via message_delta when present.
+              if output.stopReason == .stop,
+                 output.content.contains(where: { if case .toolCall = $0 { true } else { false } })
+              {
+                output.stopReason = .toolUse
+              }
 
             default:
               continue
@@ -101,5 +282,18 @@ public struct AnthropicMessagesProvider: Sendable {
         task.cancel()
       }
     }
+  }
+}
+
+private func mapAnthropicStopReason(_ stopReason: String) -> StopReason {
+  switch stopReason {
+  case "end_turn":
+    .stop
+  case "max_tokens":
+    .length
+  case "tool_use":
+    .toolUse
+  default:
+    .stop
   }
 }

--- a/Sources/PiAI/Providers/OpenAIResponsesProvider.swift
+++ b/Sources/PiAI/Providers/OpenAIResponsesProvider.swift
@@ -7,6 +7,29 @@ public struct OpenAIResponsesProvider: Sendable {
     self.http = http
   }
 
+  public func stream(model: Model, context: SimpleContext, options: RequestOptions = .init()) async throws
+    -> AsyncThrowingStream<AssistantMessageEvent, any Error>
+  {
+    guard model.provider == .openai else { throw PiAIError.unsupported("Expected provider openai") }
+
+    let apiKey = try resolveAPIKey(options.apiKey, env: "OPENAI_API_KEY", provider: model.provider)
+
+    let url = model.baseURL.appending(path: "responses")
+    var request = HTTPRequest(url: url, method: "POST")
+    request.setHeader("Bearer \(apiKey)", for: "Authorization")
+    request.setHeader("application/json", for: "Content-Type")
+    request.setHeader("text/event-stream", for: "Accept")
+    for (k, v) in options.headers {
+      request.setHeader(v, for: k)
+    }
+
+    let body = try JSONSerialization.data(withJSONObject: buildBody(model: model, context: context, options: options))
+    request.body = body
+
+    let sse = try await http.sse(for: request)
+    return mapResponsesSSE(sse, provider: model.provider, modelId: model.id)
+  }
+
   public func stream(model: Model, context: Context, options: RequestOptions = .init()) async throws
     -> AsyncThrowingStream<AssistantMessageEvent, any Error>
   {
@@ -28,6 +51,92 @@ public struct OpenAIResponsesProvider: Sendable {
 
     let sse = try await http.sse(for: request)
     return mapResponsesSSE(sse, provider: model.provider, modelId: model.id)
+  }
+
+  private func buildBody(model: Model, context: SimpleContext, options: RequestOptions) -> [String: Any] {
+    var input: [[String: Any]] = []
+    if let system = context.systemPrompt, !system.isEmpty {
+      input.append(["role": "system", "content": system])
+    }
+
+    var msgIndex = 0
+    for message in context.messages {
+      switch message {
+      case let .user(user):
+        input.append([
+          "role": "user",
+          "content": [
+            ["type": "input_text", "text": user.content],
+          ],
+        ])
+
+      case let .assistant(assistant):
+        for block in assistant.content {
+          switch block {
+          case let .text(text):
+            let id = (text.signature?.isEmpty == false) ? text.signature! : "msg_\(msgIndex)"
+            msgIndex += 1
+            input.append([
+              "type": "message",
+              "role": "assistant",
+              "status": "completed",
+              "id": id,
+              "content": [
+                ["type": "output_text", "text": text.text],
+              ],
+            ])
+
+          case let .toolCall(call):
+            let (callId, itemId) = splitOpenAIToolCallId(call.id)
+            let argsString = (try? jsonString(call.arguments)) ?? "{}"
+            input.append([
+              "type": "function_call",
+              "call_id": callId,
+              "id": itemId,
+              "name": call.name,
+              "arguments": argsString,
+            ])
+          }
+        }
+
+      case let .toolResult(result):
+        let (callId, _) = splitOpenAIToolCallId(result.toolCallId)
+        input.append([
+          "type": "function_call_output",
+          "call_id": callId,
+          "output": result.content,
+        ])
+      }
+    }
+
+    var body: [String: Any] = [
+      "model": model.id,
+      "input": input,
+      "stream": true,
+      "store": false,
+    ]
+
+    if let temperature = options.temperature {
+      body["temperature"] = temperature
+    }
+    if let maxTokens = options.maxTokens {
+      body["max_output_tokens"] = maxTokens
+    }
+    if let sessionId = options.sessionId {
+      body["prompt_cache_key"] = sessionId
+    }
+    if let tools = context.tools, !tools.isEmpty {
+      body["tools"] = tools.map { tool in
+        [
+          "type": "function",
+          "name": tool.name,
+          "description": tool.description,
+          "parameters": tool.parameters.toAny(),
+        ]
+      }
+    }
+
+    return body
   }
 
   private func buildBody(model: Model, context: Context, options: RequestOptions) -> [String: Any] {
@@ -82,14 +191,31 @@ public struct OpenAIResponsesProvider: Sendable {
 
             case "response.output_item.done":
               if let item = dict["item"] as? [String: Any],
-                 let content = item["content"] as? [[String: Any]]
+                 let itemType = item["type"] as? String
               {
-                let text = content
-                  .filter { ($0["type"] as? String) == "output_text" }
-                  .compactMap { $0["text"] as? String }
-                  .joined()
-                if !text.isEmpty {
-                  output.content = [.text(.init(text: text))]
+                if itemType == "message" {
+                  if let content = item["content"] as? [[String: Any]] {
+                    let text = content
+                      .filter { ($0["type"] as? String) == "output_text" }
+                      .compactMap { $0["text"] as? String }
+                      .joined()
+                    if !text.isEmpty {
+                      upsertAssistantText(text, into: &output)
+                    }
+                  }
+                } else if itemType == "function_call" {
+                  guard let callId = item["call_id"] as? String,
+                        let itemId = item["id"] as? String,
+                        let name = item["name"] as? String,
+                        let argsText = item["arguments"] as? String
+                  else { continue }
+                  if let argsAny = try? JSONSerialization.jsonObject(with: Data(argsText.utf8)),
+                     let args = try? JSONValue(argsAny)
+                  {
+                    output.content.append(.toolCall(.init(id: "\(callId)|\(itemId)", name: name, arguments: args)))
+                  } else {
+                    output.content.append(.toolCall(.init(id: "\(callId)|\(itemId)", name: name, arguments: .object([:]))))
+                  }
                 }
               }
 
@@ -103,12 +229,22 @@ public struct OpenAIResponsesProvider: Sendable {
                 output.usage = Usage(inputTokens: input, outputTokens: outputTokens, totalTokens: total)
               }
 
+            case "response.failed":
+              throw PiAIError.httpStatus(code: 500, body: message.data)
+
+            case "error":
+              throw PiAIError.httpStatus(code: 500, body: message.data)
+
             default:
               continue
             }
           }
 
-          output.stopReason = .stop
+          if output.content.contains(where: { if case .toolCall = $0 { true } else { false } }) {
+            output.stopReason = .toolUse
+          } else {
+            output.stopReason = .stop
+          }
           continuation.yield(.done(message: output))
           continuation.finish()
         } catch {
@@ -123,4 +259,28 @@ public struct OpenAIResponsesProvider: Sendable {
       }
     }
   }
+}
+
+private func splitOpenAIToolCallId(_ id: String) -> (callId: String, itemId: String) {
+  if let pipe = id.firstIndex(of: "|") {
+    let callId = String(id[..<pipe])
+    let itemId = String(id[id.index(after: pipe)...])
+    return (callId, itemId)
+  }
+  return (id, "fc_\(id)")
+}
+
+private func jsonString(_ value: JSONValue) throws -> String {
+  let data = try JSONSerialization.data(withJSONObject: value.toAny())
+  return String(decoding: data, as: UTF8.self)
+}
+
+private func upsertAssistantText(_ text: String, into message: inout AssistantMessage) {
+  for i in message.content.indices {
+    if case .text = message.content[i] {
+      message.content[i] = .text(.init(text: text))
+      return
+    }
+  }
+  message.content.insert(.text(.init(text: text)), at: 0)
 }

--- a/Sources/PiAI/SimpleTypes.swift
+++ b/Sources/PiAI/SimpleTypes.swift
@@ -1,0 +1,207 @@
+import Foundation
+
+public enum JSONValue: Sendable, Hashable {
+  case null
+  case bool(Bool)
+  case number(Double)
+  case string(String)
+  case array([JSONValue])
+  case object([String: JSONValue])
+
+  public init(_ value: Any?) throws {
+    switch value {
+    case nil:
+      self = .null
+    case let v as NSNull:
+      _ = v
+      self = .null
+    case let v as Bool:
+      self = .bool(v)
+    case let v as Int:
+      self = .number(Double(v))
+    case let v as Double:
+      self = .number(v)
+    case let v as Float:
+      self = .number(Double(v))
+    case let v as String:
+      self = .string(v)
+    case let v as [Any]:
+      self = try .array(v.map { try JSONValue($0) })
+    case let v as [String: Any]:
+      var obj: [String: JSONValue] = [:]
+      obj.reserveCapacity(v.count)
+      for (k, vv) in v {
+        obj[k] = try JSONValue(vv)
+      }
+      self = .object(obj)
+    default:
+      throw PiAIError.decoding("Unsupported JSON value type: \(type(of: value as Any))")
+    }
+  }
+
+  public func toAny() -> Any {
+    switch self {
+    case .null:
+      return NSNull()
+    case let .bool(v):
+      return v
+    case let .number(v):
+      return v
+    case let .string(v):
+      return v
+    case let .array(v):
+      return v.map { $0.toAny() }
+    case let .object(v):
+      var obj: [String: Any] = [:]
+      obj.reserveCapacity(v.count)
+      for (k, vv) in v {
+        obj[k] = vv.toAny()
+      }
+      return obj
+    }
+  }
+
+  public var asObject: [String: JSONValue]? {
+    if case let .object(v) = self { return v }
+    return nil
+  }
+
+  public var asString: String? {
+    if case let .string(v) = self { return v }
+    return nil
+  }
+}
+
+public struct Tool: Sendable, Hashable {
+  public var name: String
+  public var description: String
+  /// JSON Schema (subset) describing tool parameters.
+  public var parameters: JSONValue
+
+  public init(name: String, description: String, parameters: JSONValue) {
+    self.name = name
+    self.description = description
+    self.parameters = parameters
+  }
+}
+
+public struct ToolCall: Sendable, Hashable {
+  public var id: String
+  public var name: String
+  public var arguments: JSONValue
+
+  public init(id: String, name: String, arguments: JSONValue) {
+    self.id = id
+    self.name = name
+    self.arguments = arguments
+  }
+}
+
+public struct UserMessage: Sendable, Hashable {
+  public var content: String
+  public var timestamp: Date
+
+  public init(content: String, timestamp: Date = Date()) {
+    self.content = content
+    self.timestamp = timestamp
+  }
+}
+
+public struct ToolResultMessage: Sendable, Hashable {
+  public var toolCallId: String
+  public var toolName: String
+  public var content: String
+  public var isError: Bool
+  public var timestamp: Date
+
+  public init(
+    toolCallId: String,
+    toolName: String,
+    content: String,
+    isError: Bool,
+    timestamp: Date = Date(),
+  ) {
+    self.toolCallId = toolCallId
+    self.toolName = toolName
+    self.content = content
+    self.isError = isError
+    self.timestamp = timestamp
+  }
+}
+
+public enum Message: Sendable, Hashable {
+  case user(UserMessage)
+  case assistant(AssistantMessage)
+  case toolResult(ToolResultMessage)
+}
+
+public struct SimpleContext: Sendable, Hashable {
+  public var systemPrompt: String?
+  public var messages: [Message]
+  public var tools: [Tool]?
+
+  public init(systemPrompt: String? = nil, messages: [Message], tools: [Tool]? = nil) {
+    self.systemPrompt = systemPrompt
+    self.messages = messages
+    self.tools = tools
+  }
+}
+
+public func validateToolArguments(tool: Tool, toolCall: ToolCall) throws -> JSONValue {
+  try validateToolArguments(tool: tool, arguments: toolCall.arguments)
+}
+
+public func validateToolArguments(tool: Tool, arguments: JSONValue) throws -> JSONValue {
+  guard let schemaObj = tool.parameters.asObject else {
+    throw PiAIError.decoding("Tool parameters schema must be an object")
+  }
+  let schemaType = schemaObj["type"]?.asString
+  guard schemaType == "object" else {
+    throw PiAIError.unsupported("Only JSON Schema type=object is supported for tool parameters")
+  }
+
+  guard let argsObj = arguments.asObject else {
+    throw PiAIError.decoding("Tool arguments must be an object")
+  }
+
+  let requiredKeys: [String] = {
+    guard case let .array(arr)? = schemaObj["required"] else { return [] }
+    return arr.compactMap(\.asString)
+  }()
+
+  for key in requiredKeys {
+    guard argsObj[key] != nil else {
+      throw PiAIError.decoding("Missing required tool argument: \(key)")
+    }
+  }
+
+  if case let .object(props)? = schemaObj["properties"] {
+    for (key, propSchema) in props {
+      guard let value = argsObj[key] else { continue }
+      try validateSchema(propSchema, value: value, path: key)
+    }
+  }
+
+  return .object(argsObj)
+}
+
+private func validateSchema(_ schema: JSONValue, value: JSONValue, path: String) throws {
+  guard let obj = schema.asObject else { return }
+  let type = obj["type"]?.asString
+  switch type {
+  case "string":
+    guard case .string = value else { throw PiAIError.decoding("Expected string at \(path)") }
+  case "number":
+    guard case .number = value else { throw PiAIError.decoding("Expected number at \(path)") }
+  case "boolean":
+    guard case .bool = value else { throw PiAIError.decoding("Expected boolean at \(path)") }
+  case "object":
+    guard case .object = value else { throw PiAIError.decoding("Expected object at \(path)") }
+  case "array":
+    guard case .array = value else { throw PiAIError.decoding("Expected array at \(path)") }
+  case nil:
+    return
+  default:
+    throw PiAIError.unsupported("Unsupported schema type \(String(describing: type)) at \(path)")
+  }
+}

--- a/Sources/PiAI/Types.swift
+++ b/Sources/PiAI/Types.swift
@@ -112,6 +112,7 @@ public struct TextContent: Sendable, Hashable {
 
 public enum AssistantContent: Sendable, Hashable {
   case text(TextContent)
+  case toolCall(ToolCall)
 }
 
 public struct AssistantMessage: Sendable, Hashable {

--- a/Sources/PiAgent/Agent.swift
+++ b/Sources/PiAgent/Agent.swift
@@ -1,0 +1,329 @@
+import Foundation
+import PiAI
+
+public struct AgentOptions: Sendable {
+  public var initialState: AgentState?
+  public var convertToLlm: ConvertToLlm?
+  public var transformContext: TransformContext?
+  public var steeringMode: QueueMode
+  public var followUpMode: QueueMode
+  public var streamFn: StreamFn?
+  public var sessionId: String?
+  public var getApiKey: (@Sendable (_ provider: Provider) async throws -> String?)?
+  public var requestOptions: RequestOptions
+
+  public init(
+    initialState: AgentState? = nil,
+    convertToLlm: ConvertToLlm? = nil,
+    transformContext: TransformContext? = nil,
+    steeringMode: QueueMode = .oneAtATime,
+    followUpMode: QueueMode = .oneAtATime,
+    streamFn: StreamFn? = nil,
+    sessionId: String? = nil,
+    getApiKey: (@Sendable (_ provider: Provider) async throws -> String?)? = nil,
+    requestOptions: RequestOptions = .init(),
+  ) {
+    self.initialState = initialState
+    self.convertToLlm = convertToLlm
+    self.transformContext = transformContext
+    self.steeringMode = steeringMode
+    self.followUpMode = followUpMode
+    self.streamFn = streamFn
+    self.sessionId = sessionId
+    self.getApiKey = getApiKey
+    self.requestOptions = requestOptions
+  }
+}
+
+public enum QueueMode: Sendable {
+  case all
+  case oneAtATime
+}
+
+public final class Agent: @unchecked Sendable {
+  private struct Storage: Sendable {
+    var state: AgentState
+    var listeners: [UUID: @Sendable (AgentEvent) -> Void]
+    var steeringQueue: [AgentMessage]
+    var followUpQueue: [AgentMessage]
+    var cancellationToken: CancellationToken?
+    var runningTask: Task<Void, Never>?
+    var sessionId: String?
+  }
+
+  private let storage: Mutex<Storage>
+
+  public var state: AgentState {
+    storage.withLock { $0.state }
+  }
+
+  private let convertToLlm: ConvertToLlm
+  private let transformContext: TransformContext?
+  private let steeringMode: QueueMode
+  private let followUpMode: QueueMode
+  public var streamFn: StreamFn
+  private let getApiKey: (@Sendable (_ provider: Provider) async throws -> String?)?
+  private var requestOptions: RequestOptions
+
+  public init(_ options: AgentOptions = .init()) {
+    let initial = options.initialState ?? AgentState()
+    storage = Mutex(initialState: .init(
+      state: initial,
+      listeners: [:],
+      steeringQueue: [],
+      followUpQueue: [],
+      cancellationToken: nil,
+      runningTask: nil,
+      sessionId: options.sessionId,
+    ))
+    convertToLlm = options.convertToLlm ?? Agent.defaultConvertToLlm
+    transformContext = options.transformContext
+    steeringMode = options.steeringMode
+    followUpMode = options.followUpMode
+    streamFn = options.streamFn ?? DefaultStream.stream
+    getApiKey = options.getApiKey
+    requestOptions = options.requestOptions
+  }
+
+  public var sessionId: String? {
+    get {
+      storage.withLock { $0.sessionId }
+    }
+    set {
+      storage.withLock { $0.sessionId = newValue }
+    }
+  }
+
+  public func subscribe(_ fn: @escaping @Sendable (AgentEvent) -> Void) -> @Sendable () -> Void {
+    let id = UUID()
+    storage.withLock { $0.listeners[id] = fn }
+    return { [weak self] in
+      self?.storage.withLock { $0.listeners.removeValue(forKey: id) }
+    }
+  }
+
+  private func emit(_ event: AgentEvent) {
+    let fns = storage.withLock { Array($0.listeners.values) }
+    for fn in fns {
+      fn(event)
+    }
+  }
+
+  // MARK: - State mutators (do not emit events)
+
+  public func setSystemPrompt(_ v: String) {
+    storage.withLock { $0.state.systemPrompt = v }
+  }
+
+  public func setModel(_ m: Model) {
+    storage.withLock { $0.state.model = m }
+  }
+
+  public func setThinkingLevel(_ l: ThinkingLevel) {
+    storage.withLock { $0.state.thinkingLevel = l }
+  }
+
+  public func setTools(_ t: [AgentTool]) {
+    storage.withLock { $0.state.tools = t }
+  }
+
+  public func replaceMessages(_ ms: [AgentMessage]) {
+    storage.withLock { $0.state.messages = ms }
+  }
+
+  public func appendMessage(_ m: AgentMessage) {
+    storage.withLock { $0.state.messages.append(m) }
+  }
+
+  public func clearMessages() {
+    storage.withLock { $0.state.messages = [] }
+  }
+
+  // MARK: - Queues
+
+  public func steer(_ m: AgentMessage) {
+    storage.withLock { $0.steeringQueue.append(m) }
+  }
+
+  public func followUp(_ m: AgentMessage) {
+    storage.withLock { $0.followUpQueue.append(m) }
+  }
+
+  private func dequeueSteering() -> [AgentMessage] {
+    storage.withLock {
+      switch steeringMode {
+      case .oneAtATime:
+        guard let first = $0.steeringQueue.first else { return [] }
+        $0.steeringQueue.removeFirst()
+        return [first]
+      case .all:
+        let out = $0.steeringQueue
+        $0.steeringQueue = []
+        return out
+      }
+    }
+  }
+
+  private func dequeueFollowUp() -> [AgentMessage] {
+    storage.withLock {
+      switch followUpMode {
+      case .oneAtATime:
+        guard let first = $0.followUpQueue.first else { return [] }
+        $0.followUpQueue.removeFirst()
+        return [first]
+      case .all:
+        let out = $0.followUpQueue
+        $0.followUpQueue = []
+        return out
+      }
+    }
+  }
+
+  public func abort() {
+    let (token, task) = storage.withLock { ($0.cancellationToken, $0.runningTask) }
+    token?.cancel()
+    task?.cancel()
+  }
+
+  public func waitForIdle() async {
+    let task = storage.withLock { $0.runningTask }
+    _ = await task?.value
+  }
+
+  public func reset() {
+    storage.withLock {
+      $0.state.messages = []
+      $0.state.isStreaming = false
+      $0.state.streamMessage = nil
+      $0.state.pendingToolCalls = []
+      $0.state.error = nil
+      $0.steeringQueue = []
+      $0.followUpQueue = []
+    }
+  }
+
+  public func prompt(_ input: String) async throws {
+    let message = AgentMessage.llm(.user(.init(content: input)))
+    try await prompt(message)
+  }
+
+  public func prompt(_ message: AgentMessage) async throws {
+    try await prompt([message])
+  }
+
+  public func prompt(_ messages: [AgentMessage]) async throws {
+    let started = storage.withLock { storage in
+      if storage.state.isStreaming { return false }
+      storage.state.isStreaming = true
+      storage.state.error = nil
+      return true
+    }
+    guard started else { throw AgentError.alreadyProcessingPrompt }
+
+    let token = CancellationToken()
+    let (systemPrompt, existingMessages, tools) = storage.withLock { ($0.state.systemPrompt, $0.state.messages, $0.state.tools) }
+    storage.withLock { $0.cancellationToken = token }
+
+    let loopConfig = makeLoopConfig(token: token)
+    let ctx = AgentContext(systemPrompt: systemPrompt, messages: existingMessages, tools: tools)
+    let stream = agentLoop(prompts: messages, context: ctx, config: loopConfig, cancellationToken: token)
+
+    let task = Task {
+      for await event in stream {
+        emit(event)
+        if case let .messageUpdate(message, _) = event {
+          storage.withLock { $0.state.streamMessage = message }
+        }
+      }
+
+      let produced = await stream.result()
+      storage.withLock {
+        $0.state.messages.append(contentsOf: produced)
+        $0.state.isStreaming = false
+        $0.state.streamMessage = nil
+        $0.cancellationToken = nil
+        $0.runningTask = nil
+      }
+    }
+
+    storage.withLock { $0.runningTask = task }
+    await task.value
+  }
+
+  public func `continue`() async throws {
+    let (existing, systemPrompt, tools, alreadyStreaming): ([AgentMessage], String, [AgentTool], Bool) = storage.withLock {
+      let already = $0.state.isStreaming
+      if !already {
+        $0.state.isStreaming = true
+        $0.state.error = nil
+      }
+      return ($0.state.messages, $0.state.systemPrompt, $0.state.tools, already)
+    }
+    if alreadyStreaming {
+      throw AgentError.alreadyProcessingContinue
+    }
+
+    let token = CancellationToken()
+    storage.withLock { $0.cancellationToken = token }
+
+    let loopConfig = makeLoopConfig(token: token)
+    let ctx = AgentContext(systemPrompt: systemPrompt, messages: existing, tools: tools)
+    let stream = try agentLoopContinue(context: ctx, config: loopConfig, cancellationToken: token)
+
+    let task = Task {
+      for await event in stream {
+        emit(event)
+        if case let .messageUpdate(message, _) = event {
+          storage.withLock { $0.state.streamMessage = message }
+        }
+      }
+      let produced = await stream.result()
+      storage.withLock {
+        $0.state.messages.append(contentsOf: produced)
+        $0.state.isStreaming = false
+        $0.state.streamMessage = nil
+        $0.cancellationToken = nil
+        $0.runningTask = nil
+      }
+    }
+
+    storage.withLock { $0.runningTask = task }
+
+    await task.value
+  }
+
+  private func makeLoopConfig(token _: CancellationToken) -> AgentLoopConfig {
+    let model = storage.withLock { $0.state.model }
+    return AgentLoopConfig(
+      model: model,
+      convertToLlm: convertToLlm,
+      transformContext: transformContext,
+      streamFn: streamFn,
+      requestOptions: resolvedRequestOptions(),
+      getApiKey: getApiKey,
+      getSteeringMessages: { [weak self] in
+        guard let self else { return [] }
+        return dequeueSteering()
+      },
+      getFollowUpMessages: { [weak self] in
+        guard let self else { return [] }
+        return dequeueFollowUp()
+      },
+    )
+  }
+
+  private func resolvedRequestOptions() -> RequestOptions {
+    var options = requestOptions
+    options.sessionId = sessionId
+    return options
+  }
+
+  private static func defaultConvertToLlm(_ messages: [AgentMessage]) async throws -> [Message] {
+    messages.compactMap { message in
+      if case let .llm(m) = message {
+        return m
+      }
+      return nil
+    }
+  }
+}

--- a/Sources/PiAgent/AgentLoop.swift
+++ b/Sources/PiAgent/AgentLoop.swift
@@ -1,0 +1,400 @@
+import Foundation
+import PiAI
+
+private final class ProducerHolder: @unchecked Sendable {
+  private let lock = Mutex<Task<[AgentMessage], Never>?>(initialState: nil)
+
+  func set(_ task: Task<[AgentMessage], Never>) {
+    lock.withLock { $0 = task }
+  }
+
+  func get() -> Task<[AgentMessage], Never>? {
+    lock.withLock { $0 }
+  }
+
+  func cancel() {
+    get()?.cancel()
+  }
+}
+
+private final class EventSink: @unchecked Sendable {
+  private let continuation: AsyncStream<AgentEvent>.Continuation
+
+  init(_ continuation: AsyncStream<AgentEvent>.Continuation) {
+    self.continuation = continuation
+  }
+
+  func yield(_ event: AgentEvent) {
+    continuation.yield(event)
+  }
+
+  func finish() {
+    continuation.finish()
+  }
+}
+
+public func agentLoop(
+  prompts: [AgentMessage],
+  context: AgentContext,
+  config: AgentLoopConfig,
+  cancellationToken: CancellationToken? = nil,
+) -> AgentEventStream {
+  AgentEventStream(
+    prompts: prompts,
+    context: context,
+    config: config,
+    cancellationToken: cancellationToken,
+    isContinue: false,
+  )
+}
+
+public func agentLoopContinue(
+  context: AgentContext,
+  config: AgentLoopConfig,
+  cancellationToken: CancellationToken? = nil,
+) throws -> AgentEventStream {
+  guard !context.messages.isEmpty else {
+    throw AgentError.invalidContinue("Cannot continue: no messages in context")
+  }
+
+  if case let .llm(last) = context.messages.last, case .assistant = last {
+    throw AgentError.invalidContinue("Cannot continue from message role: assistant")
+  }
+
+  return AgentEventStream(
+    prompts: [],
+    context: context,
+    config: config,
+    cancellationToken: cancellationToken,
+    isContinue: true,
+  )
+}
+
+public struct AgentEventStream: AsyncSequence, Sendable {
+  public typealias Element = AgentEvent
+
+  private let stream: AsyncStream<AgentEvent>
+  private let resultTask: Task<[AgentMessage], Never>
+
+  init(
+    prompts: [AgentMessage],
+    context: AgentContext,
+    config: AgentLoopConfig,
+    cancellationToken: CancellationToken?,
+    isContinue: Bool,
+  ) {
+    let token = cancellationToken ?? CancellationToken()
+    let holder = ProducerHolder()
+
+    stream = AsyncStream { continuation in
+      let sink = EventSink(continuation)
+      continuation.onTermination = { _ in
+        holder.cancel()
+      }
+
+      let producer = Task<[AgentMessage], Never> {
+        if token.isCancelled || Task.isCancelled {
+          sink.finish()
+          return []
+        }
+
+        sink.yield(.agentStart)
+        sink.yield(.turnStart)
+        if !isContinue {
+          for prompt in prompts {
+            sink.yield(.messageStart(message: prompt))
+            sink.yield(.messageEnd(message: prompt))
+          }
+        }
+
+        var newMessages: [AgentMessage] = prompts
+        var current = context
+        current.messages.append(contentsOf: prompts)
+
+        await runLoop(
+          currentContext: &current,
+          newMessages: &newMessages,
+          config: config,
+          cancellationToken: token,
+          emit: { sink.yield($0) },
+        )
+
+        sink.yield(.agentEnd(messages: newMessages))
+        sink.finish()
+        return newMessages
+      }
+
+      holder.set(producer)
+    }
+
+    resultTask = Task {
+      while true {
+        if let task = holder.get() {
+          return await task.value
+        }
+        await Task.yield()
+      }
+    }
+  }
+
+  public func makeAsyncIterator() -> AsyncStream<AgentEvent>.Iterator {
+    stream.makeAsyncIterator()
+  }
+
+  public func result() async -> [AgentMessage] {
+    await resultTask.value
+  }
+}
+
+private func runLoop(
+  currentContext: inout AgentContext,
+  newMessages: inout [AgentMessage],
+  config: AgentLoopConfig,
+  cancellationToken: CancellationToken,
+  emit: @escaping @Sendable (AgentEvent) -> Void,
+) async {
+  var firstTurn = true
+  var pendingMessages: [AgentMessage] = await (try? config.getSteeringMessages?()) ?? []
+
+  while true {
+    var hasMoreToolCalls = true
+    var steeringAfterTools: [AgentMessage]? = nil
+
+    while hasMoreToolCalls || !pendingMessages.isEmpty {
+      if !firstTurn {
+        emit(.turnStart)
+      } else {
+        firstTurn = false
+      }
+
+      if cancellationToken.isCancelled { return }
+
+      if !pendingMessages.isEmpty {
+        for message in pendingMessages {
+          emit(.messageStart(message: message))
+          emit(.messageEnd(message: message))
+          currentContext.messages.append(message)
+          newMessages.append(message)
+        }
+        pendingMessages = []
+      }
+
+      let assistant = await streamAssistantResponse(
+        context: &currentContext,
+        config: config,
+        cancellationToken: cancellationToken,
+        emit: emit,
+      )
+
+      newMessages.append(assistant)
+
+      let (toolCalls, toolResults, steering) = await executeToolCallsIfNeeded(
+        context: &currentContext,
+        assistantMessage: assistant,
+        cancellationToken: cancellationToken,
+        emit: emit,
+        getSteeringMessages: config.getSteeringMessages,
+      )
+
+      hasMoreToolCalls = !toolCalls.isEmpty
+      steeringAfterTools = steering
+
+      for result in toolResults {
+        currentContext.messages.append(.llm(.toolResult(result)))
+        newMessages.append(.llm(.toolResult(result)))
+      }
+
+      emit(.turnEnd(message: assistant, toolResults: toolResults))
+
+      if let steering = steeringAfterTools, !steering.isEmpty {
+        pendingMessages = steering
+        steeringAfterTools = nil
+      } else {
+        pendingMessages = await (try? config.getSteeringMessages?()) ?? []
+      }
+    }
+
+    let followUps = await (try? config.getFollowUpMessages?()) ?? []
+    if !followUps.isEmpty {
+      pendingMessages = followUps
+      continue
+    }
+
+    break
+  }
+}
+
+private func streamAssistantResponse(
+  context: inout AgentContext,
+  config: AgentLoopConfig,
+  cancellationToken: CancellationToken,
+  emit: @escaping @Sendable (AgentEvent) -> Void,
+) async -> AgentMessage {
+  if cancellationToken.isCancelled {
+    let message: AgentMessage = .custom(.init(role: "error", content: "Cancelled"))
+    context.messages.append(message)
+    emit(.messageStart(message: message))
+    emit(.messageEnd(message: message))
+    return message
+  }
+
+  var messages = context.messages
+  if let transformContext = config.transformContext {
+    if let transformed = try? await transformContext(messages, cancellationToken) {
+      messages = transformed
+    }
+  }
+
+  let llmMessages = await (try? config.convertToLlm(messages)) ?? []
+  let tools = context.tools.map(\.tool)
+
+  var options = config.requestOptions
+  if let getApiKey = config.getApiKey, let key = try? await getApiKey(config.model.provider) {
+    options.apiKey = key
+  }
+
+  let llmContext = SimpleContext(
+    systemPrompt: context.systemPrompt.isEmpty ? nil : context.systemPrompt,
+    messages: llmMessages,
+    tools: tools.isEmpty ? nil : tools,
+  )
+
+  let stream: AsyncThrowingStream<AssistantMessageEvent, any Error>
+  do {
+    stream = try await config.streamFn(config.model, llmContext, options)
+  } catch {
+    let message: AgentMessage = .custom(.init(role: "error", content: String(describing: error)))
+    context.messages.append(message)
+    emit(.messageStart(message: message))
+    emit(.messageEnd(message: message))
+    return message
+  }
+
+  var partial: AssistantMessage?
+  var addedPartial = false
+  var finalMessage: AssistantMessage?
+
+  do {
+    for try await event in stream {
+      if cancellationToken.isCancelled { break }
+
+      switch event {
+      case let .start(p):
+        partial = p
+        let msg = AgentMessage.llm(.assistant(p))
+        context.messages.append(msg)
+        addedPartial = true
+        emit(.messageStart(message: msg))
+
+      case let .textDelta(delta, p):
+        partial = p
+        if addedPartial {
+          context.messages[context.messages.count - 1] = .llm(.assistant(p))
+        }
+        emit(.messageUpdate(message: .llm(.assistant(p)), assistantMessageEvent: .textDelta(delta: delta, partial: p)))
+
+      case let .done(message):
+        finalMessage = message
+      }
+    }
+  } catch {
+    finalMessage = AssistantMessage(provider: config.model.provider, model: config.model.id, stopReason: .error)
+    finalMessage?.errorMessage = String(describing: error)
+  }
+
+  let resolved = finalMessage ?? partial ?? AssistantMessage(provider: config.model.provider, model: config.model.id)
+
+  let finalAgentMessage = AgentMessage.llm(.assistant(resolved))
+  if addedPartial {
+    context.messages[context.messages.count - 1] = finalAgentMessage
+  } else {
+    context.messages.append(finalAgentMessage)
+    emit(.messageStart(message: finalAgentMessage))
+  }
+  emit(.messageEnd(message: finalAgentMessage))
+  return finalAgentMessage
+}
+
+private func executeToolCallsIfNeeded(
+  context: inout AgentContext,
+  assistantMessage: AgentMessage,
+  cancellationToken: CancellationToken,
+  emit: @escaping @Sendable (AgentEvent) -> Void,
+  getSteeringMessages: (@Sendable () async throws -> [AgentMessage])?,
+) async -> (toolCalls: [ToolCall], toolResults: [ToolResultMessage], steeringMessages: [AgentMessage]?) {
+  guard case let .llm(msg) = assistantMessage, case let .assistant(assistant) = msg else {
+    return ([], [], nil)
+  }
+
+  let toolCalls: [ToolCall] = assistant.content.compactMap { part in
+    if case let .toolCall(call) = part { return call }
+    return nil
+  }
+
+  guard !toolCalls.isEmpty else { return ([], [], nil) }
+
+  var results: [ToolResultMessage] = []
+  var steeringMessages: [AgentMessage]? = nil
+
+  for (idx, call) in toolCalls.enumerated() {
+    if cancellationToken.isCancelled { break }
+
+    emit(.toolExecutionStart(toolCallId: call.id, toolName: call.name, args: call.arguments))
+
+    var toolResult: AgentToolResult
+    var isError = false
+
+    do {
+      guard let tool = context.tools.first(where: { $0.tool.name == call.name }) else {
+        throw PiAIError.unsupported("Tool \(call.name) not found")
+      }
+
+      let validated = try validateToolArguments(tool: tool.tool, toolCall: call)
+      toolResult = try await tool.execute(call.id, validated, cancellationToken) { partial in
+        emit(.toolExecutionUpdate(toolCallId: call.id, toolName: call.name, args: call.arguments, partialResult: partial))
+      }
+    } catch {
+      toolResult = .init(content: String(describing: error), details: .object([:]))
+      isError = true
+    }
+
+    emit(.toolExecutionEnd(toolCallId: call.id, toolName: call.name, result: toolResult, isError: isError))
+
+    let toolResultMessage = ToolResultMessage(
+      toolCallId: call.id,
+      toolName: call.name,
+      content: toolResult.content,
+      isError: isError,
+    )
+
+    results.append(toolResultMessage)
+    emit(.messageStart(message: .llm(.toolResult(toolResultMessage))))
+    emit(.messageEnd(message: .llm(.toolResult(toolResultMessage))))
+
+    if let getSteeringMessages, let steering = try? await getSteeringMessages(), !steering.isEmpty {
+      steeringMessages = steering
+      let remaining = toolCalls.suffix(from: idx + 1)
+      for skipped in remaining {
+        let skippedResult = ToolResultMessage(
+          toolCallId: skipped.id,
+          toolName: skipped.name,
+          content: "Skipped due to queued user message.",
+          isError: true,
+        )
+        results.append(skippedResult)
+        emit(.toolExecutionStart(toolCallId: skipped.id, toolName: skipped.name, args: skipped.arguments))
+        emit(.toolExecutionEnd(
+          toolCallId: skipped.id,
+          toolName: skipped.name,
+          result: .init(content: skippedResult.content, details: .object([:])),
+          isError: true,
+        ))
+        emit(.messageStart(message: .llm(.toolResult(skippedResult))))
+        emit(.messageEnd(message: .llm(.toolResult(skippedResult))))
+      }
+      break
+    }
+  }
+
+  return (toolCalls, results, steeringMessages)
+}

--- a/Sources/PiAgent/DefaultStream.swift
+++ b/Sources/PiAgent/DefaultStream.swift
@@ -1,0 +1,47 @@
+import Foundation
+import PiAI
+
+public enum DefaultStream {
+  public static func stream(model: Model, context: SimpleContext, options: RequestOptions = .init()) async throws
+    -> AsyncThrowingStream<AssistantMessageEvent, any Error>
+  {
+    switch model.provider {
+    case .openai:
+      let provider = OpenAIResponsesProvider()
+      let inner = try await provider.stream(model: model, context: context, options: options)
+      return AsyncThrowingStream { continuation in
+        let task = Task {
+          _ = provider
+          do {
+            for try await event in inner {
+              continuation.yield(event)
+            }
+            continuation.finish()
+          } catch {
+            continuation.finish(throwing: error)
+          }
+        }
+        continuation.onTermination = { _ in task.cancel() }
+      }
+    case .anthropic:
+      let provider = AnthropicMessagesProvider()
+      let inner = try await provider.stream(model: model, context: context, options: options)
+      return AsyncThrowingStream { continuation in
+        let task = Task {
+          _ = provider
+          do {
+            for try await event in inner {
+              continuation.yield(event)
+            }
+            continuation.finish()
+          } catch {
+            continuation.finish(throwing: error)
+          }
+        }
+        continuation.onTermination = { _ in task.cancel() }
+      }
+    case .openaiCodex:
+      throw PiAIError.unsupported("PiAgent DefaultStream does not support openai-codex yet")
+    }
+  }
+}

--- a/Sources/PiAgent/Errors.swift
+++ b/Sources/PiAgent/Errors.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+public enum AgentError: Error, Sendable, CustomStringConvertible, Equatable {
+  case alreadyProcessingPrompt
+  case alreadyProcessingContinue
+  case invalidContinue(String)
+
+  public var description: String {
+    switch self {
+    case .alreadyProcessingPrompt:
+      "Agent is already processing a prompt. Use steer() or followUp() to queue messages, or wait for completion."
+    case .alreadyProcessingContinue:
+      "Agent is already processing. Wait for completion before continuing."
+    case let .invalidContinue(message):
+      message
+    }
+  }
+}

--- a/Sources/PiAgent/Mutex.swift
+++ b/Sources/PiAgent/Mutex.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+#if canImport(Darwin)
+  import Darwin
+#else
+  import Glibc
+#endif
+
+final class Mutex<State>: @unchecked Sendable {
+  private var mutex = pthread_mutex_t()
+  private var state: State
+
+  init(initialState: State) {
+    state = initialState
+    var attr = pthread_mutexattr_t()
+    pthread_mutexattr_init(&attr)
+    pthread_mutexattr_settype(&attr, Int32(PTHREAD_MUTEX_NORMAL))
+    pthread_mutex_init(&mutex, &attr)
+    pthread_mutexattr_destroy(&attr)
+  }
+
+  deinit {
+    pthread_mutex_destroy(&mutex)
+  }
+
+  @discardableResult
+  func withLock<R>(_ body: (inout State) throws -> R) rethrows -> R {
+    pthread_mutex_lock(&mutex)
+    defer { pthread_mutex_unlock(&mutex) }
+    return try body(&state)
+  }
+
+  func snapshot() -> State {
+    withLock { $0 }
+  }
+}

--- a/Sources/PiAgent/Types.swift
+++ b/Sources/PiAgent/Types.swift
@@ -1,0 +1,195 @@
+import Foundation
+import PiAI
+
+public enum ThinkingLevel: String, Sendable {
+  case off
+  case minimal
+  case low
+  case medium
+  case high
+  case xhigh
+}
+
+public struct CustomAgentMessage: Sendable, Hashable {
+  public var role: String
+  public var content: String
+  public var timestamp: Date
+
+  public init(role: String, content: String, timestamp: Date = Date()) {
+    self.role = role
+    self.content = content
+    self.timestamp = timestamp
+  }
+}
+
+public enum AgentMessage: Sendable, Hashable {
+  case llm(Message)
+  case custom(CustomAgentMessage)
+
+  public var role: String {
+    switch self {
+    case let .llm(m):
+      switch m {
+      case .user: "user"
+      case .assistant: "assistant"
+      case .toolResult: "toolResult"
+      }
+    case let .custom(m):
+      m.role
+    }
+  }
+}
+
+public struct AgentToolResult: Sendable, Hashable {
+  public var content: String
+  public var details: JSONValue
+
+  public init(content: String, details: JSONValue = .object([:])) {
+    self.content = content
+    self.details = details
+  }
+}
+
+public typealias AgentToolUpdateCallback = @Sendable (_ partialResult: AgentToolResult) -> Void
+
+public struct AgentTool: Sendable {
+  public var tool: Tool
+  public var label: String
+  public var execute: @Sendable (
+    _ toolCallId: String,
+    _ params: JSONValue,
+    _ cancellationToken: CancellationToken?,
+    _ onUpdate: AgentToolUpdateCallback?,
+  ) async throws -> AgentToolResult
+
+  public init(
+    tool: Tool,
+    label: String,
+    execute: @escaping @Sendable (
+      _ toolCallId: String,
+      _ params: JSONValue,
+      _ cancellationToken: CancellationToken?,
+      _ onUpdate: AgentToolUpdateCallback?,
+    ) async throws -> AgentToolResult,
+  ) {
+    self.tool = tool
+    self.label = label
+    self.execute = execute
+  }
+}
+
+public struct AgentContext: Sendable {
+  public var systemPrompt: String
+  public var messages: [AgentMessage]
+  public var tools: [AgentTool]
+
+  public init(systemPrompt: String, messages: [AgentMessage], tools: [AgentTool] = []) {
+    self.systemPrompt = systemPrompt
+    self.messages = messages
+    self.tools = tools
+  }
+}
+
+public typealias ConvertToLlm = @Sendable (_ messages: [AgentMessage]) async throws -> [Message]
+public typealias TransformContext = @Sendable (_ messages: [AgentMessage], _ cancellationToken: CancellationToken?) async
+  throws -> [AgentMessage]
+
+public typealias StreamFn = @Sendable (_ model: Model, _ context: SimpleContext, _ options: RequestOptions) async throws
+  -> AsyncThrowingStream<AssistantMessageEvent, any Error>
+
+public struct AgentLoopConfig: Sendable {
+  public var model: Model
+  public var convertToLlm: ConvertToLlm
+  public var transformContext: TransformContext?
+  public var streamFn: StreamFn
+  public var requestOptions: RequestOptions
+  public var getApiKey: (@Sendable (_ provider: Provider) async throws -> String?)?
+  public var getSteeringMessages: (@Sendable () async throws -> [AgentMessage])?
+  public var getFollowUpMessages: (@Sendable () async throws -> [AgentMessage])?
+
+  public init(
+    model: Model,
+    convertToLlm: @escaping ConvertToLlm,
+    transformContext: TransformContext? = nil,
+    streamFn: @escaping StreamFn = DefaultStream.stream,
+    requestOptions: RequestOptions = .init(),
+    getApiKey: (@Sendable (_ provider: Provider) async throws -> String?)? = nil,
+    getSteeringMessages: (@Sendable () async throws -> [AgentMessage])? = nil,
+    getFollowUpMessages: (@Sendable () async throws -> [AgentMessage])? = nil,
+  ) {
+    self.model = model
+    self.convertToLlm = convertToLlm
+    self.transformContext = transformContext
+    self.streamFn = streamFn
+    self.requestOptions = requestOptions
+    self.getApiKey = getApiKey
+    self.getSteeringMessages = getSteeringMessages
+    self.getFollowUpMessages = getFollowUpMessages
+  }
+}
+
+public enum AgentEvent: Sendable, Hashable {
+  case agentStart
+  case agentEnd(messages: [AgentMessage])
+
+  case turnStart
+  case turnEnd(message: AgentMessage, toolResults: [ToolResultMessage])
+
+  case messageStart(message: AgentMessage)
+  case messageUpdate(message: AgentMessage, assistantMessageEvent: AssistantMessageEvent)
+  case messageEnd(message: AgentMessage)
+
+  case toolExecutionStart(toolCallId: String, toolName: String, args: JSONValue)
+  case toolExecutionUpdate(toolCallId: String, toolName: String, args: JSONValue, partialResult: AgentToolResult)
+  case toolExecutionEnd(toolCallId: String, toolName: String, result: AgentToolResult, isError: Bool)
+}
+
+public struct AgentState: Sendable {
+  public var systemPrompt: String
+  public var model: Model
+  public var thinkingLevel: ThinkingLevel
+  public var tools: [AgentTool]
+  public var messages: [AgentMessage]
+  public var isStreaming: Bool
+  public var streamMessage: AgentMessage?
+  public var pendingToolCalls: Set<String>
+  public var error: String?
+
+  public init(
+    systemPrompt: String = "",
+    model: Model = .init(id: "gpt-4.1-mini", provider: .openai),
+    thinkingLevel: ThinkingLevel = .off,
+    tools: [AgentTool] = [],
+    messages: [AgentMessage] = [],
+    isStreaming: Bool = false,
+    streamMessage: AgentMessage? = nil,
+    pendingToolCalls: Set<String> = [],
+    error: String? = nil,
+  ) {
+    self.systemPrompt = systemPrompt
+    self.model = model
+    self.thinkingLevel = thinkingLevel
+    self.tools = tools
+    self.messages = messages
+    self.isStreaming = isStreaming
+    self.streamMessage = streamMessage
+    self.pendingToolCalls = pendingToolCalls
+    self.error = error
+  }
+}
+
+public final class CancellationToken: @unchecked Sendable {
+  private let lock: Mutex<Bool>
+
+  public init() {
+    lock = Mutex(initialState: false)
+  }
+
+  public func cancel() {
+    lock.withLock { $0 = true }
+  }
+
+  public var isCancelled: Bool {
+    lock.withLock { $0 }
+  }
+}

--- a/Sources/wuhu/main.swift
+++ b/Sources/wuhu/main.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 import Foundation
 import GRDB
+import PiAgent
 import PiAI
 
 @inline(never)
@@ -12,8 +13,8 @@ private func _ensureGRDBIsLinked() {
 struct Wuhu: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "wuhu",
-    abstract: "Wuhu (Swift) – small demo CLI for PiAI providers.",
-    subcommands: [OpenAI.self, Anthropic.self],
+    abstract: "Wuhu (Swift) – mini demo CLI for PiAI + PiAgent.",
+    subcommands: [Agent.self, OpenAI.self, Anthropic.self],
   )
 
   struct Shared: ParsableArguments {
@@ -96,6 +97,148 @@ struct Wuhu: AsyncParsableCommand {
       }
     }
   }
+
+  struct Agent: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "agent",
+      abstract: "Run a minimal agent loop with tool calling.",
+    )
+
+    enum Backend: String, ExpressibleByArgument, Sendable {
+      case openai
+      case anthropic
+    }
+
+    @Option(help: "Backend/provider to use.")
+    var backend: Backend = .openai
+
+    @Option(help: "Model id (defaults vary by backend).")
+    var model: String?
+
+    @Option(help: "System prompt (optional).")
+    var systemPrompt: String =
+      "You are a helpful assistant. For any weather question, you must use the `weather` tool for each city you need. Do not guess."
+
+    @OptionGroup
+    var shared: Shared
+
+    func run() async throws {
+      _ensureGRDBIsLinked()
+      try DotEnv.loadIfPresent(path: shared.envFile)
+
+      let prompt = readStdinPrompt()
+      guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        throw ValidationError("No prompt provided on stdin.")
+      }
+
+      let provider: Provider
+      let modelId: String
+      switch backend {
+      case .openai:
+        provider = .openai
+        modelId = model ?? "gpt-4.1-mini"
+      case .anthropic:
+        provider = .anthropic
+        modelId = model ?? "claude-sonnet-4-5"
+      }
+
+      let weatherTool = makeWeatherTool()
+
+      let agent = PiAgent.Agent(.init(initialState: .init(
+        systemPrompt: systemPrompt,
+        model: .init(id: modelId, provider: provider),
+        tools: [weatherTool],
+      )))
+
+      final class DeltaTracker: @unchecked Sendable {
+        var sawAssistantTextDelta = false
+      }
+      let tracker = DeltaTracker()
+
+      _ = agent.subscribe { event in
+        switch event {
+        case let .messageStart(message):
+          if message.role == "assistant" {
+            tracker.sawAssistantTextDelta = false
+          }
+        case let .messageUpdate(_, assistantMessageEvent):
+          if case let .textDelta(delta, _) = assistantMessageEvent {
+            tracker.sawAssistantTextDelta = true
+            FileHandle.standardOutput.write(Data(delta.utf8))
+          }
+        case let .messageEnd(message):
+          if message.role == "assistant", tracker.sawAssistantTextDelta == false {
+            if let text = assistantText(from: message), !text.isEmpty {
+              FileHandle.standardOutput.write(Data(text.utf8))
+            }
+            if let error = assistantError(from: message) {
+              FileHandle.standardError.write(Data("\n[agent:error] \(error)\n".utf8))
+            }
+          }
+          if message.role == "error", case let .custom(custom) = message {
+            FileHandle.standardError.write(Data("\n[agent:error] \(custom.content)\n".utf8))
+          }
+        case let .toolExecutionStart(toolCallId, toolName, args):
+          FileHandle.standardError.write(Data("\n[tool:start] \(toolName) id=\(toolCallId) args=\(args)\n".utf8))
+        case let .toolExecutionEnd(toolCallId, toolName, result, isError):
+          FileHandle.standardError.write(
+            Data("[tool:end] \(toolName) id=\(toolCallId) error=\(isError) result=\(result.content)\n".utf8),
+          )
+        default:
+          break
+        }
+      }
+
+      try await agent.prompt(prompt)
+      FileHandle.standardOutput.write(Data("\n".utf8))
+    }
+
+    private func readStdinPrompt() -> String {
+      if let data = try? FileHandle.standardInput.readToEnd(), !data.isEmpty {
+        return String(decoding: data, as: UTF8.self)
+      }
+      return ""
+    }
+
+    private func assistantText(from message: AgentMessage) -> String? {
+      guard case let .llm(m) = message, case let .assistant(assistant) = m else { return nil }
+      return assistant.content.compactMap { part in
+        if case let .text(text) = part { return text.text }
+        return nil
+      }.joined()
+    }
+
+    private func assistantError(from message: AgentMessage) -> String? {
+      guard case let .llm(m) = message, case let .assistant(assistant) = m else { return nil }
+      guard assistant.stopReason == .error else { return nil }
+      return assistant.errorMessage
+    }
+
+    private func makeWeatherTool() -> AgentTool {
+      let schema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+          "city": .object([
+            "type": .string("string"),
+            "description": .string("City name, e.g. San Francisco"),
+          ]),
+        ]),
+        "required": .array([.string("city")]),
+      ])
+
+      let tool = Tool(
+        name: "weather",
+        description: "Get the current weather for a city (demo tool; returns synthetic data).",
+        parameters: schema,
+      )
+
+      return AgentTool(tool: tool, label: "Weather") { _, params, _, _ in
+        let city = params.asObject?["city"]?.asString ?? "Unknown"
+        let report = WeatherTool.fakeWeatherReport(for: city)
+        return AgentToolResult(content: report, details: .object(["city": .string(city)]))
+      }
+    }
+  }
 }
 
 enum DotEnv {
@@ -123,5 +266,34 @@ enum DotEnv {
         setenv(key, value, 0)
       }
     }
+  }
+}
+
+enum WeatherTool {
+  static func fakeWeatherReport(for city: String) -> String {
+    let baseTempF = switch city.lowercased() {
+    case "san francisco", "sf":
+      60
+    case "san diego", "sd":
+      75
+    case "tokyo":
+      70
+    case "new york", "nyc":
+      55
+    default:
+      65
+    }
+
+    // Add a little randomness, but keep San Diego hotter than San Francisco for the demo.
+    let jitter = Int.random(in: -2 ... 2)
+    let tempF = baseTempF + jitter
+    let humidity = Int.random(in: 35 ... 75)
+    let windMph = Int.random(in: 0 ... 18)
+    return """
+    Weather for \(city):
+    - temperature_f: \(tempF)
+    - humidity_percent: \(humidity)
+    - wind_mph: \(windMph)
+    """
   }
 }

--- a/Tests/PiAgentTests/AgentLoopTests.swift
+++ b/Tests/PiAgentTests/AgentLoopTests.swift
@@ -1,0 +1,333 @@
+import Foundation
+import PiAgent
+import PiAI
+import Testing
+
+private actor BoolBox {
+  var value: Bool
+  init(_ value: Bool = false) {
+    self.value = value
+  }
+
+  func set(_ v: Bool) {
+    value = v
+  }
+
+  func get() -> Bool {
+    value
+  }
+}
+
+private actor IntBox {
+  var value: Int
+  init(_ value: Int = 0) {
+    self.value = value
+  }
+
+  func set(_ v: Int) {
+    value = v
+  }
+
+  func get() -> Int {
+    value
+  }
+}
+
+private actor StringRecorder {
+  var values: [String] = []
+  func append(_ v: String) {
+    values.append(v)
+  }
+
+  func snapshot() -> [String] {
+    values
+  }
+}
+
+private func makeUsage() -> Usage {
+  .init(inputTokens: 0, outputTokens: 0, totalTokens: 0)
+}
+
+private func makeAssistantMessage(
+  content: [AssistantContent],
+  stopReason: StopReason = .stop,
+) -> AssistantMessage {
+  AssistantMessage(
+    provider: .openai,
+    model: "mock",
+    content: content,
+    usage: makeUsage(),
+    stopReason: stopReason,
+  )
+}
+
+private func makeUserMessage(_ text: String) -> AgentMessage {
+  .llm(.user(.init(content: text)))
+}
+
+private func identityConverter(messages: [AgentMessage]) async throws -> [Message] {
+  messages.compactMap {
+    if case let .llm(m) = $0 { return m }
+    return nil
+  }
+}
+
+private func mockStreamFn(
+  select: @escaping @Sendable (_ context: SimpleContext) -> AssistantMessage,
+) -> StreamFn {
+  { model, context, _ in
+    _ = model
+    let message = select(context)
+    return AsyncThrowingStream { continuation in
+      continuation.yield(.start(partial: makeAssistantMessage(content: [])))
+      continuation.yield(.done(message: message))
+      continuation.finish()
+    }
+  }
+}
+
+struct AgentLoopTests {
+  @Test func emitsEventsAndReturnsNewMessages() async {
+    let context = AgentContext(systemPrompt: "You are helpful.", messages: [], tools: [])
+    let prompt = makeUserMessage("Hello")
+
+    let config = AgentLoopConfig(
+      model: .init(id: "gpt-4.1-mini", provider: .openai),
+      convertToLlm: identityConverter,
+      streamFn: mockStreamFn(select: { _ in makeAssistantMessage(content: [.text(.init(text: "Hi"))]) }),
+    )
+
+    var events: [AgentEvent] = []
+    let stream = agentLoop(prompts: [prompt], context: context, config: config)
+    for await event in stream {
+      events.append(event)
+    }
+
+    let produced = await stream.result()
+    #expect(produced.count == 2)
+    #expect(produced[0].role == "user")
+    #expect(produced[1].role == "assistant")
+
+    let eventTypes = events.map { "\($0)" }
+    #expect(eventTypes.contains(where: { $0.contains("agentStart") }))
+    #expect(eventTypes.contains(where: { $0.contains("turnStart") }))
+    #expect(eventTypes.contains(where: { $0.contains("messageStart") }))
+    #expect(eventTypes.contains(where: { $0.contains("messageEnd") }))
+    #expect(eventTypes.contains(where: { $0.contains("turnEnd") }))
+    #expect(eventTypes.contains(where: { $0.contains("agentEnd") }))
+  }
+
+  @Test func filtersCustomMessagesViaConvertToLlm() async {
+    let notification: AgentMessage = .custom(.init(role: "notification", content: "note"))
+    let context = AgentContext(systemPrompt: "", messages: [notification], tools: [])
+    let prompt = makeUserMessage("Hello")
+
+    let convertedCount = IntBox()
+    let config = AgentLoopConfig(
+      model: .init(id: "gpt-4.1-mini", provider: .openai),
+      convertToLlm: { messages in
+        let llm = messages.compactMap { if case let .llm(m) = $0 { m } else { nil } }
+        await convertedCount.set(llm.count)
+        return llm
+      },
+      streamFn: mockStreamFn(select: { _ in makeAssistantMessage(content: [.text(.init(text: "Response"))]) }),
+    )
+
+    let stream = agentLoop(prompts: [prompt], context: context, config: config)
+    for await _ in stream {}
+    #expect(await convertedCount.get() == 1) // only the user prompt
+  }
+
+  @Test func appliesTransformContextBeforeConvertToLlm() async {
+    let context = AgentContext(
+      systemPrompt: "",
+      messages: [
+        makeUserMessage("old 1"),
+        .llm(.assistant(makeAssistantMessage(content: [.text(.init(text: "resp 1"))]))),
+        makeUserMessage("old 2"),
+        .llm(.assistant(makeAssistantMessage(content: [.text(.init(text: "resp 2"))]))),
+      ],
+      tools: [],
+    )
+
+    let prompt = makeUserMessage("new")
+
+    let transformedCount = IntBox()
+    let convertedCount = IntBox()
+
+    let config = AgentLoopConfig(
+      model: .init(id: "gpt-4.1-mini", provider: .openai),
+      convertToLlm: { messages in
+        let llm = try await identityConverter(messages: messages)
+        await convertedCount.set(llm.count)
+        return llm
+      },
+      transformContext: { messages, _ in
+        let pruned = Array(messages.suffix(2))
+        await transformedCount.set(pruned.count)
+        return pruned
+      },
+      streamFn: mockStreamFn(select: { _ in makeAssistantMessage(content: [.text(.init(text: "Response"))]) }),
+    )
+
+    let stream = agentLoop(prompts: [prompt], context: context, config: config)
+    for await _ in stream {}
+
+    #expect(await transformedCount.get() == 2)
+    #expect(await convertedCount.get() == 2)
+  }
+
+  @Test func handlesToolCallsAndResults() async {
+    let schema: JSONValue = .object([
+      "type": .string("object"),
+      "properties": .object([
+        "value": .object(["type": .string("string")]),
+      ]),
+      "required": .array([.string("value")]),
+    ])
+
+    let executed = StringRecorder()
+    let tool = AgentTool(
+      tool: .init(name: "echo", description: "Echo", parameters: schema),
+      label: "Echo",
+      execute: { _, params, _, _ in
+        let v = params.asObject?["value"]?.asString ?? ""
+        await executed.append(v)
+        return .init(content: "echoed: \(v)", details: .object(["value": .string(v)]))
+      },
+    )
+
+    let context = AgentContext(systemPrompt: "", messages: [], tools: [tool])
+    let prompt = makeUserMessage("echo something")
+
+    let first = makeAssistantMessage(
+      content: [.toolCall(.init(id: "tool-1", name: "echo", arguments: .object(["value": .string("hello")])))],
+      stopReason: .toolUse,
+    )
+    let second = makeAssistantMessage(content: [.text(.init(text: "done"))], stopReason: .stop)
+
+    let config = AgentLoopConfig(
+      model: .init(id: "gpt-4.1-mini", provider: .openai),
+      convertToLlm: identityConverter,
+      streamFn: mockStreamFn(select: { context in
+        let hasToolResult = context.messages.contains { message in
+          if case .toolResult = message { return true }
+          return false
+        }
+        return hasToolResult ? second : first
+      }),
+    )
+
+    var events: [AgentEvent] = []
+    let stream = agentLoop(prompts: [prompt], context: context, config: config)
+    for await event in stream {
+      events.append(event)
+    }
+
+    #expect(await executed.snapshot() == ["hello"])
+    #expect(events.contains(where: { if case .toolExecutionStart = $0 { true } else { false } }))
+    #expect(events.contains(where: { if case .toolExecutionEnd = $0 { true } else { false } }))
+  }
+
+  @Test func injectsSteeringAndSkipsRemainingTools() async {
+    let schema: JSONValue = .object([
+      "type": .string("object"),
+      "properties": .object([
+        "value": .object(["type": .string("string")]),
+      ]),
+      "required": .array([.string("value")]),
+    ])
+
+    let executed = StringRecorder()
+    let tool = AgentTool(
+      tool: .init(name: "echo", description: "Echo", parameters: schema),
+      label: "Echo",
+      execute: { _, params, _, _ in
+        await executed.append(params.asObject?["value"]?.asString ?? "")
+        return .init(content: "ok", details: .object([:]))
+      },
+    )
+
+    let prompt = makeUserMessage("start")
+    let queued = makeUserMessage("interrupt")
+
+    let delivered = BoolBox(false)
+    let sawInterruptInContext = BoolBox(false)
+
+    let assistantWithTwoTools = makeAssistantMessage(
+      content: [
+        .toolCall(.init(id: "tool-1", name: "echo", arguments: .object(["value": .string("first")]))),
+        .toolCall(.init(id: "tool-2", name: "echo", arguments: .object(["value": .string("second")]))),
+      ],
+      stopReason: .toolUse,
+    )
+    let assistantDone = makeAssistantMessage(content: [.text(.init(text: "done"))], stopReason: .stop)
+
+    let config = AgentLoopConfig(
+      model: .init(id: "gpt-4.1-mini", provider: .openai),
+      convertToLlm: identityConverter,
+      streamFn: { model, ctx, options in
+        _ = options
+        // second call should include interrupt message in llm context
+        if model.provider == .openai,
+           ctx.messages.count > 0,
+           ctx.messages.contains(where: { m in
+             if case let .user(u) = m { return u.content == "interrupt" }
+             return false
+           })
+        {
+          await sawInterruptInContext.set(true)
+        }
+        let hasToolResult = ctx.messages.contains { message in
+          if case .toolResult = message { return true }
+          return false
+        }
+        let message = hasToolResult ? assistantDone : assistantWithTwoTools
+        return AsyncThrowingStream { continuation in
+          continuation.yield(.start(partial: makeAssistantMessage(content: [])))
+          continuation.yield(.done(message: message))
+          continuation.finish()
+        }
+      },
+      getSteeringMessages: {
+        let exec = await executed.snapshot()
+        if exec.count == 1, await delivered.get() == false {
+          await delivered.set(true)
+          return [queued]
+        }
+        return []
+      },
+    )
+
+    let context = AgentContext(systemPrompt: "", messages: [], tools: [tool])
+    var toolEnds: [Bool] = []
+    let stream = agentLoop(prompts: [prompt], context: context, config: config)
+    for await event in stream {
+      if case let .toolExecutionEnd(_, _, _, isError) = event {
+        toolEnds.append(isError)
+      }
+    }
+
+    #expect(await executed.snapshot() == ["first"])
+    #expect(toolEnds.count == 2)
+    #expect(toolEnds[0] == false)
+    #expect(toolEnds[1] == true)
+    #expect(await sawInterruptInContext.get() == true)
+  }
+
+  @Test func continueThrowsWithNoMessages() throws {
+    let context = AgentContext(systemPrompt: "", messages: [], tools: [])
+    let config = AgentLoopConfig(
+      model: .init(id: "gpt-4.1-mini", provider: .openai),
+      convertToLlm: identityConverter,
+      streamFn: mockStreamFn(select: { _ in makeAssistantMessage(content: [.text(.init(text: "x"))]) }),
+    )
+
+    do {
+      _ = try agentLoopContinue(context: context, config: config)
+      #expect(Bool(false))
+    } catch let error as AgentError {
+      #expect(error == .invalidContinue("Cannot continue: no messages in context"))
+    }
+  }
+}

--- a/Tests/PiAgentTests/AgentTests.swift
+++ b/Tests/PiAgentTests/AgentTests.swift
@@ -1,0 +1,219 @@
+import Foundation
+import PiAgent
+import PiAI
+import Testing
+
+private actor BoolBox {
+  var value: Bool
+  init(_ value: Bool = false) {
+    self.value = value
+  }
+
+  func set(_ v: Bool) {
+    value = v
+  }
+
+  func get() -> Bool {
+    value
+  }
+}
+
+private actor IntBox {
+  var value: Int
+  init(_ value: Int = 0) {
+    self.value = value
+  }
+
+  func set(_ v: Int) {
+    value = v
+  }
+
+  func get() -> Int {
+    value
+  }
+}
+
+private actor StringBox {
+  var value: String?
+  func set(_ v: String?) {
+    value = v
+  }
+
+  func get() -> String? {
+    value
+  }
+}
+
+private func makeAssistantMessage(text: String) -> AssistantMessage {
+  AssistantMessage(
+    provider: .openai,
+    model: "mock",
+    content: [.text(.init(text: text))],
+    usage: .init(inputTokens: 0, outputTokens: 0, totalTokens: 0),
+    stopReason: .stop,
+  )
+}
+
+private func makeMockStream(finalText: String) -> AsyncThrowingStream<AssistantMessageEvent, any Error> {
+  AsyncThrowingStream { continuation in
+    let msg = makeAssistantMessage(text: finalText)
+    continuation.yield(.start(partial: makeAssistantMessage(text: "")))
+    continuation.yield(.textDelta(delta: finalText, partial: msg))
+    continuation.yield(.done(message: msg))
+    continuation.finish()
+  }
+}
+
+struct AgentTests {
+  @Test func createsDefaultState() {
+    let agent = Agent()
+    #expect(agent.state.systemPrompt == "")
+    #expect(agent.state.model.provider == .openai)
+    #expect(agent.state.thinkingLevel == .off)
+    #expect(agent.state.tools.isEmpty)
+    #expect(agent.state.messages.isEmpty)
+    #expect(agent.state.isStreaming == false)
+    #expect(agent.state.streamMessage == nil)
+    #expect(agent.state.pendingToolCalls.isEmpty)
+    #expect(agent.state.error == nil)
+  }
+
+  @Test func createsCustomInitialState() {
+    let agent = Agent(.init(initialState: .init(
+      systemPrompt: "You are a helpful assistant.",
+      model: .init(id: "claude-sonnet-4-5", provider: .anthropic),
+      thinkingLevel: .low,
+    )))
+
+    #expect(agent.state.systemPrompt == "You are a helpful assistant.")
+    #expect(agent.state.model.provider == .anthropic)
+    #expect(agent.state.thinkingLevel == .low)
+  }
+
+  @Test func subscribesAndUnsubscribes() async {
+    let agent = Agent()
+    let count = IntBox()
+    let unsubscribe = agent.subscribe { _ in
+      Task {
+        await count.set(count.get() + 1)
+      }
+    }
+
+    agent.setSystemPrompt("x")
+    #expect(await count.get() == 0)
+
+    unsubscribe()
+    agent.setSystemPrompt("y")
+    #expect(await count.get() == 0)
+  }
+
+  @Test func updatesStateWithMutators() {
+    let agent = Agent()
+
+    agent.setSystemPrompt("Custom")
+    #expect(agent.state.systemPrompt == "Custom")
+
+    agent.setModel(.init(id: "claude-sonnet-4-5", provider: .anthropic))
+    #expect(agent.state.model.provider == .anthropic)
+
+    agent.setThinkingLevel(.high)
+    #expect(agent.state.thinkingLevel == .high)
+
+    agent.setTools([])
+    #expect(agent.state.tools.isEmpty)
+
+    let messages: [AgentMessage] = [.llm(.user(.init(content: "Hello")))]
+    agent.replaceMessages(messages)
+    #expect(agent.state.messages == messages)
+
+    let appended: AgentMessage = .custom(.init(role: "note", content: "Hi"))
+    agent.appendMessage(appended)
+    #expect(agent.state.messages.count == 2)
+    #expect(agent.state.messages.last == appended)
+
+    agent.clearMessages()
+    #expect(agent.state.messages.isEmpty)
+  }
+
+  @Test func queuesSteeringAndFollowUp() {
+    let agent = Agent()
+    agent.steer(.llm(.user(.init(content: "Steer"))))
+    agent.followUp(.llm(.user(.init(content: "Follow"))))
+    // queued messages are not appended to state.messages until a run
+    #expect(agent.state.messages.isEmpty)
+  }
+
+  @Test func abortDoesNotThrow() {
+    let agent = Agent()
+    agent.abort()
+  }
+
+  @Test func promptThrowsWhenStreaming() async throws {
+    let tokenSeen = BoolBox(false)
+    let agent = Agent(.init(streamFn: { _, _, _ in
+      await tokenSeen.set(true)
+      return AsyncThrowingStream { continuation in
+        continuation.yield(AssistantMessageEvent.start(partial: makeAssistantMessage(text: "")))
+        // never finish until cancelled
+      }
+    }))
+
+    let firstTask = Task { try await agent.prompt("First") }
+
+    // Give it a moment to set isStreaming.
+    try await Task.sleep(nanoseconds: 30_000_000)
+    #expect(agent.state.isStreaming == true)
+    #expect(await tokenSeen.get() == true)
+
+    do {
+      try await agent.prompt("Second")
+      #expect(Bool(false))
+    } catch let error as AgentError {
+      #expect(error == .alreadyProcessingPrompt)
+    }
+
+    agent.abort()
+    _ = try? await firstTask.value
+  }
+
+  @Test func continueThrowsWhenStreaming() async throws {
+    let agent = Agent(.init(streamFn: { _, _, _ in
+      AsyncThrowingStream { continuation in
+        continuation.yield(AssistantMessageEvent.start(partial: makeAssistantMessage(text: "")))
+        // never finish
+      }
+    }))
+
+    let firstTask = Task { try await agent.prompt("First") }
+    try await Task.sleep(nanoseconds: 30_000_000)
+    #expect(agent.state.isStreaming == true)
+
+    do {
+      try await agent.continue()
+      #expect(Bool(false))
+    } catch let error as AgentError {
+      #expect(error == .alreadyProcessingContinue)
+    }
+
+    agent.abort()
+    _ = try? await firstTask.value
+  }
+
+  @Test func forwardsSessionIdToStreamFnOptions() async throws {
+    let seenSessionId = StringBox()
+    let agent = Agent(.init(
+      streamFn: { _, _, options in
+        await seenSessionId.set(options.sessionId)
+        return makeMockStream(finalText: "ok")
+      },
+      sessionId: "session-abc",
+    ))
+
+    try await agent.prompt("hello")
+    #expect(await seenSessionId.get() == "session-abc")
+
+    agent.sessionId = "session-def"
+    try await agent.prompt("hello again")
+    #expect(await seenSessionId.get() == "session-def")
+  }
+}


### PR DESCRIPTION
Ports pi-agent core concepts to Swift as a new PiAgent target and adds an interactive-ish  demo that exercises tool calling (synthetic weather tool). Includes PiAgentTests ported from pi-agent unit tests and extends PiAI providers to support tool calls via SimpleContext.