### PR TITLE
Port PiAgent to Swift + agent demo CLI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
   ],
   products: [
     .library(name: "PiAI", targets: ["PiAI"]),
+    .library(name: "PiAgent", targets: ["PiAgent"]),
     .executable(name: "wuhu", targets: ["wuhu"]),
   ],
   dependencies: [
@@ -40,10 +41,18 @@ let package = Package(
       ],
       swiftSettings: strictConcurrency,
     ),
+    .target(
+      name: "PiAgent",
+      dependencies: [
+        "PiAI",
+      ],
+      swiftSettings: strictConcurrency,
+    ),
     .executableTarget(
       name: "wuhu",
       dependencies: [
         "PiAI",
+        "PiAgent",
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
         .product(name: "GRDB", package: "GRDB.swift"),
       ],
@@ -53,6 +62,14 @@ let package = Package(
       name: "PiAITests",
       dependencies: [
         "PiAI",
+        .product(name: "Testing", package: "swift-testing"),
+      ],
+      swiftSettings: strictConcurrency,
+    ),
+    .testTarget(
+      name: "PiAgentTests",
+      dependencies: [
+        "PiAgent",
         .product(name: "Testing", package: "swift-testing"),
       ],
       swiftSettings: strictConcurrency,

--- a/Sources/PiAI/Internal/ProviderHelpers.swift
+++ b/Sources/PiAI/Internal/ProviderHelpers.swift
@@ -13,11 +13,10 @@ func parseJSON(_ text: String) throws -> [String: Any]? {
 }
 
 func applyTextDelta(_ delta: String, to message: inout AssistantMessage) {
-  switch message.content.first {
-  case var .text(part):
+  if let last = message.content.last, case var .text(part) = last {
     part.text += delta
-    message.content = [.text(part)]
-  default:
-    message.content = [.text(.init(text: delta))]
+    message.content[message.content.count - 1] = .text(part)
+  } else {
+    message.content.append(.text(.init(text: delta)))
   }
 }

--- a/Sources/PiAI/JSONValue.swift
+++ b/Sources/PiAI/JSONValue.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+/// A Sendable, Hashable representation of JSON.
+///
+/// This is used for tool schemas and tool call arguments/results.
+public enum JSONValue: Sendable, Hashable, Codable {
+  case null
+  case bool(Bool)
+  case number(Double)
+  case string(String)
+  case array([JSONValue])
+  case object([String: JSONValue])
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if container.decodeNil() {
+      self = .null
+      return
+    }
+    if let bool = try? container.decode(Bool.self) {
+      self = .bool(bool)
+      return
+    }
+    if let number = try? container.decode(Double.self) {
+      self = .number(number)
+      return
+    }
+    if let string = try? container.decode(String.self) {
+      self = .string(string)
+      return
+    }
+    if let array = try? container.decode([JSONValue].self) {
+      self = .array(array)
+      return
+    }
+    if let object = try? container.decode([String: JSONValue].self) {
+      self = .object(object)
+      return
+    }
+    throw DecodingError.typeMismatch(
+      JSONValue.self,
+      .init(codingPath: decoder.codingPath, debugDescription: "Unsupported JSON value"),
+    )
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .null:
+      try container.encodeNil()
+    case let .bool(value):
+      try container.encode(value)
+    case let .number(value):
+      try container.encode(value)
+    case let .string(value):
+      try container.encode(value)
+    case let .array(value):
+      try container.encode(value)
+    case let .object(value):
+      try container.encode(value)
+    }
+  }
+
+  public static func fromAny(_ any: Any) throws -> JSONValue {
+    switch any {
+    case is NSNull:
+      return .null
+    case let value as Bool:
+      return .bool(value)
+    case let value as Int:
+      return .number(Double(value))
+    case let value as Double:
+      return .number(value)
+    case let value as Float:
+      return .number(Double(value))
+    case let value as String:
+      return .string(value)
+    case let value as [Any]:
+      return try .array(value.map(JSONValue.fromAny))
+    case let value as [String: Any]:
+      var object: [String: JSONValue] = [:]
+      object.reserveCapacity(value.count)
+      for (k, v) in value {
+        object[k] = try JSONValue.fromAny(v)
+      }
+      return .object(object)
+    default:
+      throw PiAIError.decoding("Unsupported JSON value type: \(type(of: any))")
+    }
+  }
+
+  public func toAny() -> Any {
+    switch self {
+    case .null:
+      NSNull()
+    case let .bool(value):
+      value
+    case let .number(value):
+      value
+    case let .string(value):
+      value
+    case let .array(value):
+      value.map { $0.toAny() }
+    case let .object(value):
+      value.mapValues { $0.toAny() }
+    }
+  }
+}
+
+public extension JSONValue {
+  var object: [String: JSONValue]? {
+    if case let .object(value) = self { return value }
+    return nil
+  }
+
+  var array: [JSONValue]? {
+    if case let .array(value) = self { return value }
+    return nil
+  }
+
+  var stringValue: String? {
+    if case let .string(value) = self { return value }
+    return nil
+  }
+
+  var doubleValue: Double? {
+    if case let .number(value) = self { return value }
+    return nil
+  }
+
+  var boolValue: Bool? {
+    if case let .bool(value) = self { return value }
+    return nil
+  }
+}

--- a/Sources/PiAI/PiAI.swift
+++ b/Sources/PiAI/PiAI.swift
@@ -1,3 +1,22 @@
 public enum PiAI {
-  // Namespace
+  /// Keep a single HTTP client alive for the lifetime of the process. Some streaming bodies
+  /// are backed by the underlying client's connection lifecycle; if the client is deallocated
+  /// mid-stream (e.g. when providers are created as temporaries), the request can be cancelled.
+  private static let sharedHTTPClient = AsyncHTTPClientTransport()
+
+  /// Stream a response from the model using the provider inferred from `model.provider`.
+  public static func streamSimple(
+    model: Model,
+    context: Context,
+    options: RequestOptions = .init(),
+  ) async throws -> AsyncThrowingStream<AssistantMessageEvent, any Error> {
+    switch model.provider {
+    case .openai:
+      try await OpenAIResponsesProvider(http: sharedHTTPClient).stream(model: model, context: context, options: options)
+    case .openaiCodex:
+      try await OpenAICodexResponsesProvider(http: sharedHTTPClient).stream(model: model, context: context, options: options)
+    case .anthropic:
+      try await AnthropicMessagesProvider(http: sharedHTTPClient).stream(model: model, context: context, options: options)
+    }
+  }
 }

--- a/Sources/PiAI/Providers/AnthropicMessagesProvider.swift
+++ b/Sources/PiAI/Providers/AnthropicMessagesProvider.swift
@@ -32,18 +32,94 @@ public struct AnthropicMessagesProvider: Sendable {
   }
 
   private func buildBody(model: Model, context: Context, options: RequestOptions) -> [String: Any] {
-    var messages: [[String: Any]] = []
-    for message in context.messages {
-      messages.append([
-        "role": message.role == .user ? "user" : "assistant",
-        "content": message.content,
-      ])
+    var params: [[String: Any]] = []
+
+    var i = 0
+    while i < context.messages.count {
+      let message = context.messages[i]
+
+      switch message {
+      case let .user(m):
+        let text = m.content.compactMap { block -> String? in
+          if case let .text(part) = block { return part.text }
+          return nil
+        }.joined(separator: "\n")
+
+        if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+          i += 1
+          continue
+        }
+
+        params.append([
+          "role": "user",
+          "content": [
+            [
+              "type": "text",
+              "text": text,
+            ],
+          ],
+        ])
+        i += 1
+
+      case let .assistant(m):
+        var blocks: [[String: Any]] = []
+        for block in m.content {
+          switch block {
+          case let .text(part):
+            if part.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { continue }
+            blocks.append([
+              "type": "text",
+              "text": part.text,
+            ])
+          case let .toolCall(call):
+            blocks.append([
+              "type": "tool_use",
+              "id": call.id,
+              "name": call.name,
+              "input": call.arguments.toAny(),
+            ])
+          }
+        }
+        if !blocks.isEmpty {
+          params.append([
+            "role": "assistant",
+            "content": blocks,
+          ])
+        }
+        i += 1
+
+      case .toolResult:
+        var toolResults: [[String: Any]] = []
+        while i < context.messages.count {
+          guard case let .toolResult(m) = context.messages[i] else { break }
+
+          let text = m.content.compactMap { block -> String? in
+            if case let .text(part) = block { return part.text }
+            return nil
+          }.joined(separator: "\n")
+
+          toolResults.append([
+            "type": "tool_result",
+            "tool_use_id": m.toolCallId,
+            "content": text.isEmpty ? "(no output)" : text,
+            "is_error": m.isError,
+          ])
+          i += 1
+        }
+
+        if !toolResults.isEmpty {
+          params.append([
+            "role": "user",
+            "content": toolResults,
+          ])
+        }
+      }
     }
 
     var body: [String: Any] = [
       "model": model.id,
       "stream": true,
-      "messages": messages,
+      "messages": params,
       "max_tokens": options.maxTokens ?? 1024,
     ]
 
@@ -52,6 +128,16 @@ public struct AnthropicMessagesProvider: Sendable {
     }
     if let temperature = options.temperature {
       body["temperature"] = temperature
+    }
+
+    if let tools = context.tools, !tools.isEmpty {
+      body["tools"] = tools.map { tool in
+        [
+          "name": tool.name,
+          "description": tool.description,
+          "input_schema": tool.parameters.toAny(),
+        ] as [String: Any]
+      }
     }
 
     return body
@@ -67,29 +153,96 @@ public struct AnthropicMessagesProvider: Sendable {
         var output = AssistantMessage(provider: provider, model: modelId)
         continuation.yield(.start(partial: output))
 
+        var currentTextIndex: Int?
+        var currentToolCallIndex: Int?
+        var currentToolCallArgumentsBuffer = ""
+
         do {
           for try await message in sse {
             guard let event = message.event else { continue }
             guard let dict = try parseJSON(message.data) else { continue }
 
             switch event {
+            case "content_block_start":
+              if let block = dict["content_block"] as? [String: Any],
+                 let type = block["type"] as? String
+              {
+                if type == "text" {
+                  output.content.append(.text(.init(text: "")))
+                  currentTextIndex = output.content.count - 1
+                  currentToolCallIndex = nil
+                  currentToolCallArgumentsBuffer = ""
+                } else if type == "tool_use" {
+                  let id = block["id"] as? String ?? UUID().uuidString
+                  let name = block["name"] as? String ?? "tool"
+                  let inputAny = block["input"] ?? [:]
+                  let args = (try? JSONValue.fromAny(inputAny)) ?? .object([:])
+                  output.content.append(.toolCall(.init(id: id, name: name, arguments: args)))
+                  currentToolCallIndex = output.content.count - 1
+                  currentTextIndex = nil
+                  currentToolCallArgumentsBuffer = ""
+                }
+              }
+
             case "content_block_delta":
               if let delta = dict["delta"] as? [String: Any],
-                 (delta["type"] as? String) == "text_delta",
-                 let text = delta["text"] as? String
+                 let deltaType = delta["type"] as? String
               {
-                applyTextDelta(text, to: &output)
-                continuation.yield(.textDelta(delta: text, partial: output))
+                if deltaType == "text_delta", let text = delta["text"] as? String {
+                  if let idx = currentTextIndex,
+                     idx >= 0,
+                     idx < output.content.count,
+                     case var .text(part) = output.content[idx]
+                  {
+                    part.text += text
+                    output.content[idx] = .text(part)
+                  } else {
+                    applyTextDelta(text, to: &output)
+                  }
+                  continuation.yield(.textDelta(delta: text, partial: output))
+                } else if deltaType == "input_json_delta", let partial = delta["partial_json"] as? String {
+                  currentToolCallArgumentsBuffer += partial
+                }
+              }
+
+            case "content_block_stop":
+              if let idx = currentToolCallIndex,
+                 !currentToolCallArgumentsBuffer.isEmpty,
+                 idx >= 0,
+                 idx < output.content.count,
+                 case let .toolCall(existing) = output.content[idx]
+              {
+                let args = parseJSONValueLenient(currentToolCallArgumentsBuffer) ?? existing.arguments
+                output.content[idx] = .toolCall(.init(id: existing.id, name: existing.name, arguments: args))
+              }
+              currentTextIndex = nil
+              currentToolCallIndex = nil
+              currentToolCallArgumentsBuffer = ""
+
+            case "message_delta":
+              if let delta = dict["delta"] as? [String: Any],
+                 let stopReason = delta["stop_reason"] as? String
+              {
+                output.stopReason = mapAnthropicStopReason(stopReason)
               }
 
             case "message_stop":
-              output.stopReason = .stop
+              if output.stopReason == .stop,
+                 output.content.contains(where: { if case .toolCall = $0 { true } else { false } })
+              {
+                output.stopReason = .toolUse
+              }
 
             default:
               continue
             }
           }
 
+          if output.stopReason == .stop,
+             output.content.contains(where: { if case .toolCall = $0 { true } else { false } })
+          {
+            output.stopReason = .toolUse
+          }
           continuation.yield(.done(message: output))
           continuation.finish()
         } catch {
@@ -101,5 +254,34 @@ public struct AnthropicMessagesProvider: Sendable {
         task.cancel()
       }
     }
+  }
+}
+
+private func parseJSONValueLenient(_ text: String) -> JSONValue? {
+  let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+  guard !trimmed.isEmpty else { return nil }
+  guard let data = trimmed.data(using: .utf8) else { return nil }
+  do {
+    let any = try JSONSerialization.jsonObject(with: data)
+    return try JSONValue.fromAny(any)
+  } catch {
+    return nil
+  }
+}
+
+private func mapAnthropicStopReason(_ reason: String) -> StopReason {
+  switch reason {
+  case "end_turn":
+    .stop
+  case "max_tokens":
+    .length
+  case "tool_use":
+    .toolUse
+  case "refusal", "sensitive":
+    .error
+  case "pause_turn", "stop_sequence":
+    .stop
+  default:
+    .stop
   }
 }

--- a/Sources/PiAI/Providers/OpenAICodexResponsesProvider.swift
+++ b/Sources/PiAI/Providers/OpenAICodexResponsesProvider.swift
@@ -43,7 +43,26 @@ public struct OpenAICodexResponsesProvider: Sendable {
   private func buildBody(model: Model, context: Context, options: RequestOptions) -> [String: Any] {
     var input: [[String: Any]] = []
     for message in context.messages {
-      input.append(["role": message.role.rawValue, "content": message.content])
+      switch message {
+      case let .user(m):
+        let text = m.content.compactMap { block -> String? in
+          if case let .text(part) = block { return part.text }
+          return nil
+        }.joined(separator: "\n")
+        input.append(["role": "user", "content": text])
+      case let .assistant(m):
+        let text = m.content.compactMap { block -> String? in
+          if case let .text(part) = block { return part.text }
+          return nil
+        }.joined(separator: "\n")
+        input.append(["role": "assistant", "content": text])
+      case let .toolResult(m):
+        let text = m.content.compactMap { block -> String? in
+          if case let .text(part) = block { return part.text }
+          return nil
+        }.joined(separator: "\n")
+        input.append(["role": "tool", "content": text])
+      }
     }
 
     var body: [String: Any] = [

--- a/Sources/PiAI/Providers/OpenAIResponsesProvider.swift
+++ b/Sources/PiAI/Providers/OpenAIResponsesProvider.swift
@@ -32,11 +32,81 @@ public struct OpenAIResponsesProvider: Sendable {
 
   private func buildBody(model: Model, context: Context, options: RequestOptions) -> [String: Any] {
     var input: [[String: Any]] = []
+
     if let system = context.systemPrompt, !system.isEmpty {
-      input.append(["role": "system", "content": system])
+      input.append([
+        "role": "system",
+        "content": system,
+      ])
     }
+
+    var msgIndex = 0
     for message in context.messages {
-      input.append(["role": message.role.rawValue, "content": message.content])
+      switch message {
+      case let .user(m):
+        let text = m.content.compactMap { block -> String? in
+          if case let .text(part) = block { return part.text }
+          return nil
+        }.joined(separator: "\n")
+        if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { continue }
+        input.append([
+          "role": "user",
+          "content": [
+            [
+              "type": "input_text",
+              "text": text,
+            ],
+          ],
+        ])
+
+      case let .assistant(m):
+        for block in m.content {
+          switch block {
+          case let .text(part):
+            let id = normalizeOpenAIItemId(part.signature ?? "msg_\(msgIndex)")
+            input.append([
+              "type": "message",
+              "role": "assistant",
+              "content": [
+                [
+                  "type": "output_text",
+                  "text": part.text,
+                  "annotations": [],
+                ],
+              ],
+              "status": "completed",
+              "id": id,
+            ])
+            msgIndex += 1
+
+          case let .toolCall(call):
+            let (callId, itemId) = splitToolCallId(call.id)
+            var obj: [String: Any] = [
+              "type": "function_call",
+              "call_id": callId,
+              "name": call.name,
+              "arguments": jsonString(call.arguments),
+            ]
+            if let itemId {
+              obj["id"] = itemId
+            }
+            input.append(obj)
+          }
+        }
+
+      case let .toolResult(m):
+        let outputText = m.content.compactMap { block -> String? in
+          if case let .text(part) = block { return part.text }
+          return nil
+        }.joined(separator: "\n")
+
+        let (callId, _) = splitToolCallId(m.toolCallId)
+        input.append([
+          "type": "function_call_output",
+          "call_id": callId,
+          "output": outputText.isEmpty ? "(no output)" : outputText,
+        ])
+      }
     }
 
     var body: [String: Any] = [
@@ -45,6 +115,18 @@ public struct OpenAIResponsesProvider: Sendable {
       "stream": true,
       "store": false,
     ]
+
+    if let tools = context.tools, !tools.isEmpty {
+      body["tools"] = tools.map { tool in
+        [
+          "type": "function",
+          "name": tool.name,
+          "description": tool.description,
+          "parameters": tool.parameters.toAny(),
+          "strict": false,
+        ] as [String: Any]
+      }
+    }
 
     if let temperature = options.temperature {
       body["temperature"] = temperature
@@ -69,28 +151,90 @@ public struct OpenAIResponsesProvider: Sendable {
         var output = AssistantMessage(provider: provider, model: modelId)
         continuation.yield(.start(partial: output))
 
+        var currentTextIndex: Int?
+        var currentToolCallIndex: Int?
+        var currentToolCallId: String?
+        var currentToolCallName: String?
+        var currentToolCallArgumentsBuffer = ""
+
         do {
           for try await message in sse {
             guard let dict = try parseJSON(message.data) else { continue }
             guard let type = dict["type"] as? String else { continue }
 
             switch type {
+            case "response.output_item.added":
+              guard let item = dict["item"] as? [String: Any],
+                    let itemType = item["type"] as? String
+              else { continue }
+
+              if itemType == "message" {
+                output.content.append(.text(.init(text: "")))
+                currentTextIndex = output.content.count - 1
+                currentToolCallIndex = nil
+                currentToolCallId = nil
+                currentToolCallName = nil
+                currentToolCallArgumentsBuffer = ""
+              } else if itemType == "function_call" {
+                let callId = item["call_id"] as? String ?? UUID().uuidString
+                let itemId = item["id"] as? String
+                let name = item["name"] as? String ?? "tool"
+
+                let fullId = itemId.map { "\(callId)|\($0)" } ?? callId
+                output.content.append(.toolCall(.init(id: fullId, name: name, arguments: .object([:]))))
+                currentToolCallIndex = output.content.count - 1
+                currentToolCallId = fullId
+                currentToolCallName = name
+                currentToolCallArgumentsBuffer = item["arguments"] as? String ?? ""
+                currentTextIndex = nil
+              }
+
             case "response.output_text.delta":
               guard let delta = dict["delta"] as? String else { continue }
-              applyTextDelta(delta, to: &output)
+              if let idx = currentTextIndex,
+                 idx >= 0,
+                 idx < output.content.count,
+                 case var .text(part) = output.content[idx]
+              {
+                part.text += delta
+                output.content[idx] = .text(part)
+              } else {
+                applyTextDelta(delta, to: &output)
+              }
               continuation.yield(.textDelta(delta: delta, partial: output))
 
+            case "response.function_call_arguments.delta":
+              guard let delta = dict["delta"] as? String else { continue }
+              guard currentToolCallIndex != nil else { continue }
+              currentToolCallArgumentsBuffer += delta
+
+            case "response.function_call_arguments.done":
+              if let arguments = dict["arguments"] as? String, !arguments.isEmpty {
+                currentToolCallArgumentsBuffer = arguments
+              }
+
             case "response.output_item.done":
-              if let item = dict["item"] as? [String: Any],
-                 let content = item["content"] as? [[String: Any]]
-              {
-                let text = content
-                  .filter { ($0["type"] as? String) == "output_text" }
-                  .compactMap { $0["text"] as? String }
-                  .joined()
-                if !text.isEmpty {
-                  output.content = [.text(.init(text: text))]
+              guard let item = dict["item"] as? [String: Any],
+                    let itemType = item["type"] as? String
+              else { continue }
+
+              if itemType == "message" {
+                currentTextIndex = nil
+              } else if itemType == "function_call" {
+                let argsText = (currentToolCallArgumentsBuffer.isEmpty ? (item["arguments"] as? String) : currentToolCallArgumentsBuffer) ?? ""
+                if let idx = currentToolCallIndex,
+                   idx >= 0,
+                   idx < output.content.count,
+                   let id = currentToolCallId,
+                   let name = currentToolCallName
+                {
+                  let args = parseJSONValueLenient(argsText) ?? .object([:])
+                  output.content[idx] = .toolCall(.init(id: id, name: name, arguments: args))
                 }
+                currentToolCallIndex = nil
+                currentToolCallId = nil
+                currentToolCallName = nil
+                currentToolCallArgumentsBuffer = ""
               }
 
             case "response.completed":
@@ -102,13 +246,25 @@ public struct OpenAIResponsesProvider: Sendable {
                 let total = usage["total_tokens"] as? Int ?? (input + outputTokens)
                 output.usage = Usage(inputTokens: input, outputTokens: outputTokens, totalTokens: total)
               }
+              if let response = dict["response"] as? [String: Any],
+                 let status = response["status"] as? String
+              {
+                output.stopReason = mapOpenAIResponsesStopReason(status)
+              }
+              if output.content.contains(where: { if case .toolCall = $0 { true } else { false } }) {
+                output.stopReason = .toolUse
+              }
 
             default:
               continue
             }
           }
 
-          output.stopReason = .stop
+          if output.stopReason == .stop,
+             output.content.contains(where: { if case .toolCall = $0 { true } else { false } })
+          {
+            output.stopReason = .toolUse
+          }
           continuation.yield(.done(message: output))
           continuation.finish()
         } catch {
@@ -122,5 +278,55 @@ public struct OpenAIResponsesProvider: Sendable {
         task.cancel()
       }
     }
+  }
+}
+
+private func splitToolCallId(_ id: String) -> (callId: String, itemId: String?) {
+  let parts = id.split(separator: "|", maxSplits: 1, omittingEmptySubsequences: false)
+  if parts.count == 2 {
+    return (String(parts[0]), String(parts[1]))
+  }
+  return (id, nil)
+}
+
+private func jsonString(_ value: JSONValue) -> String {
+  if case let .string(s) = value { return s }
+  if let data = try? JSONSerialization.data(withJSONObject: value.toAny()),
+     let text = String(data: data, encoding: .utf8)
+  {
+    return text
+  }
+  return "{}"
+}
+
+private func parseJSONValueLenient(_ text: String) -> JSONValue? {
+  let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+  guard !trimmed.isEmpty else { return nil }
+  guard let data = trimmed.data(using: .utf8) else { return nil }
+  do {
+    let any = try JSONSerialization.jsonObject(with: data)
+    return try JSONValue.fromAny(any)
+  } catch {
+    return nil
+  }
+}
+
+private func normalizeOpenAIItemId(_ raw: String) -> String {
+  if raw.count <= 64 { return raw }
+  return String(raw.prefix(64)).trimmingCharacters(in: CharacterSet(charactersIn: "_"))
+}
+
+private func mapOpenAIResponsesStopReason(_ status: String) -> StopReason {
+  switch status {
+  case "completed":
+    .stop
+  case "incomplete":
+    .length
+  case "failed", "cancelled":
+    .error
+  case "in_progress", "queued":
+    .stop
+  default:
+    .stop
   }
 }

--- a/Sources/PiAgent/Agent.swift
+++ b/Sources/PiAgent/Agent.swift
@@ -1,0 +1,330 @@
+import Foundation
+import PiAI
+
+public struct AgentState: Sendable {
+  public var systemPrompt: String
+  public var model: Model
+  public var tools: [AnyAgentTool]
+  public var messages: [Message]
+
+  public var isStreaming: Bool
+  public var streamMessage: Message?
+  public var pendingToolCalls: Set<String>
+  public var error: String?
+
+  public init(
+    systemPrompt: String = "",
+    model: Model,
+    tools: [AnyAgentTool] = [],
+    messages: [Message] = [],
+    isStreaming: Bool = false,
+    streamMessage: Message? = nil,
+    pendingToolCalls: Set<String> = [],
+    error: String? = nil,
+  ) {
+    self.systemPrompt = systemPrompt
+    self.model = model
+    self.tools = tools
+    self.messages = messages
+    self.isStreaming = isStreaming
+    self.streamMessage = streamMessage
+    self.pendingToolCalls = pendingToolCalls
+    self.error = error
+  }
+}
+
+public struct AgentOptions: Sendable {
+  public var initialState: AgentState?
+  public var requestOptions: RequestOptions
+  public var streamFn: StreamFn
+  public var maxTurns: Int?
+
+  public init(
+    initialState: AgentState? = nil,
+    requestOptions: RequestOptions = .init(),
+    streamFn: @escaping StreamFn = PiAI.streamSimple,
+    maxTurns: Int? = nil,
+  ) {
+    self.initialState = initialState
+    self.requestOptions = requestOptions
+    self.streamFn = streamFn
+    self.maxTurns = maxTurns
+  }
+}
+
+public actor Agent {
+  public nonisolated let events: AsyncThrowingStream<AgentEvent, any Error>
+  private let eventsContinuation: AsyncThrowingStream<AgentEvent, any Error>.Continuation
+
+  private var steeringQueue: [Message] = []
+  private var followUpQueue: [Message] = []
+  private var steeringMode: QueueMode = .oneAtATime
+  private var followUpMode: QueueMode = .oneAtATime
+
+  private var runningTask: Task<Void, any Error>?
+  private var requestOptions: RequestOptions
+  private var streamFn: StreamFn
+  private var maxTurns: Int?
+  private var skipInitialSteeringPoll = false
+
+  private var _state: AgentState
+
+  public init(opts: AgentOptions) {
+    var captured: AsyncThrowingStream<AgentEvent, any Error>.Continuation?
+    events = AsyncThrowingStream(AgentEvent.self, bufferingPolicy: .bufferingNewest(1024)) { continuation in
+      captured = continuation
+    }
+    eventsContinuation = captured!
+
+    streamFn = opts.streamFn
+    requestOptions = opts.requestOptions
+    maxTurns = opts.maxTurns
+
+    if let state = opts.initialState {
+      _state = state
+    } else {
+      _state = AgentState(model: Model(id: "gpt-4.1-mini", provider: .openai))
+    }
+  }
+
+  deinit {
+    eventsContinuation.finish()
+  }
+
+  public var state: AgentState {
+    _state
+  }
+
+  public func setSystemPrompt(_ v: String) {
+    _state.systemPrompt = v
+  }
+
+  public func setModel(_ m: Model) {
+    _state.model = m
+  }
+
+  public func setTools(_ t: [AnyAgentTool]) {
+    _state.tools = t
+  }
+
+  public func replaceMessages(_ ms: [Message]) {
+    _state.messages = ms
+  }
+
+  public func appendMessage(_ m: Message) {
+    _state.messages.append(m)
+  }
+
+  public func clearMessages() {
+    _state.messages = []
+  }
+
+  public func setSteeringMode(_ mode: QueueMode) {
+    steeringMode = mode
+  }
+
+  public func setFollowUpMode(_ mode: QueueMode) {
+    followUpMode = mode
+  }
+
+  public func steer(_ m: Message) {
+    steeringQueue.append(m)
+  }
+
+  public func followUp(_ m: Message) {
+    followUpQueue.append(m)
+  }
+
+  public func clearSteeringQueue() {
+    steeringQueue = []
+  }
+
+  public func clearFollowUpQueue() {
+    followUpQueue = []
+  }
+
+  public func abort() {
+    runningTask?.cancel()
+  }
+
+  public func waitForIdle() async {
+    _ = try? await runningTask?.value
+  }
+
+  public func reset() {
+    _state.messages = []
+    _state.isStreaming = false
+    _state.streamMessage = nil
+    _state.pendingToolCalls = []
+    _state.error = nil
+    steeringQueue = []
+    followUpQueue = []
+  }
+
+  public func prompt(_ input: String) async throws {
+    try await prompt([.user(input)])
+  }
+
+  public func prompt(_ messages: [Message]) async throws {
+    if _state.isStreaming {
+      throw PiAIError.unsupported(
+        "Agent is already processing a prompt. Use steer() or followUp() to queue messages, or wait for completion.",
+      )
+    }
+    try await runLoop(prompts: messages, mode: .start)
+  }
+
+  public func `continue`() async throws {
+    if _state.isStreaming {
+      throw PiAIError.unsupported("Agent is already processing. Wait for completion before continuing.")
+    }
+    guard !_state.messages.isEmpty else { throw AgentLoopContinueError.noMessages }
+
+    if case .assistant = _state.messages.last {
+      let queuedSteering = dequeueSteeringMessages()
+      if !queuedSteering.isEmpty {
+        try await runLoop(prompts: queuedSteering, mode: .start, skipInitialSteeringPoll: true)
+        return
+      }
+
+      let queuedFollowUp = dequeueFollowUpMessages()
+      if !queuedFollowUp.isEmpty {
+        try await runLoop(prompts: queuedFollowUp, mode: .start)
+        return
+      }
+
+      throw AgentLoopContinueError.lastMessageIsAssistant
+    }
+
+    try await runLoop(prompts: [], mode: .continue)
+  }
+
+  private func runLoop(prompts: [Message], mode: AgentLoopMode, skipInitialSteeringPoll: Bool = false) async throws {
+    _state.isStreaming = true
+    _state.streamMessage = nil
+    _state.error = nil
+
+    self.skipInitialSteeringPoll = skipInitialSteeringPoll
+
+    let task = Task<Void, any Error> {
+      defer { Task { await self.finishRun() } }
+
+      let cfg = AgentLoopConfig(
+        model: self._state.model,
+        requestOptions: self.requestOptions,
+        maxTurns: self.maxTurns,
+        transformContext: nil,
+        getSteeringMessages: { [weak self] in
+          guard let self else { return [] }
+          return await dequeueSteeringMessagesForLoop()
+        },
+        getFollowUpMessages: { [weak self] in
+          guard let self else { return [] }
+          return await dequeueFollowUpMessagesForLoop()
+        },
+        streamFn: self.streamFn,
+      )
+
+      let ctx = AgentContext(
+        systemPrompt: self._state.systemPrompt,
+        messages: self._state.messages,
+        tools: self._state.tools,
+      )
+
+      let stream: AsyncThrowingStream<AgentEvent, any Error> = switch mode {
+      case .start:
+        agentLoop(prompts: prompts, context: ctx, config: cfg)
+      case .continue:
+        try agentLoopContinue(context: ctx, config: cfg)
+      }
+
+      for try await event in stream {
+        self.handle(event)
+      }
+    }
+
+    runningTask = task
+    do {
+      try await task.value
+    } catch {
+      throw error
+    }
+  }
+
+  private func finishRun() async {
+    _state.isStreaming = false
+    _state.streamMessage = nil
+    _state.pendingToolCalls = []
+  }
+
+  private func handle(_ event: AgentEvent) {
+    eventsContinuation.yield(event)
+
+    switch event {
+    case let .messageStart(message):
+      if case .assistant = message {
+        _state.streamMessage = message
+      }
+
+    case let .messageUpdate(message, _):
+      if case .assistant = message {
+        _state.streamMessage = message
+      }
+
+    case let .messageEnd(message):
+      _state.streamMessage = nil
+      _state.messages.append(message)
+
+    case let .toolExecutionStart(toolCallId, _, _):
+      _state.pendingToolCalls.insert(toolCallId)
+
+    case let .toolExecutionEnd(toolCallId, _, _, _):
+      _state.pendingToolCalls.remove(toolCallId)
+
+    case let .turnEnd(assistant, _):
+      if assistant.stopReason == .error || assistant.stopReason == .aborted {
+        _state.error = assistant.errorMessage ?? "Unknown error"
+      }
+
+    default:
+      break
+    }
+  }
+
+  private func dequeueSteeringMessages() -> [Message] {
+    dequeue(from: &steeringQueue, mode: steeringMode)
+  }
+
+  private func dequeueFollowUpMessages() -> [Message] {
+    dequeue(from: &followUpQueue, mode: followUpMode)
+  }
+
+  private func dequeueSteeringMessagesForLoop() -> [Message] {
+    if skipInitialSteeringPoll {
+      skipInitialSteeringPoll = false
+      return []
+    }
+    return dequeueSteeringMessages()
+  }
+
+  private func dequeueFollowUpMessagesForLoop() -> [Message] {
+    dequeueFollowUpMessages()
+  }
+}
+
+public enum QueueMode: Sendable {
+  case all
+  case oneAtATime
+}
+
+private func dequeue(from queue: inout [Message], mode: QueueMode) -> [Message] {
+  switch mode {
+  case .oneAtATime:
+    if queue.isEmpty { return [] }
+    return [queue.removeFirst()]
+  case .all:
+    let all = queue
+    queue.removeAll(keepingCapacity: true)
+    return all
+  }
+}

--- a/Sources/PiAgent/AgentEvent.swift
+++ b/Sources/PiAgent/AgentEvent.swift
@@ -1,0 +1,18 @@
+import Foundation
+import PiAI
+
+public enum AgentEvent: Sendable {
+  case agentStart
+  case agentEnd(messages: [Message])
+
+  case turnStart
+  case turnEnd(assistant: AssistantMessage, toolResults: [ToolResultMessage])
+
+  case messageStart(message: Message)
+  case messageUpdate(message: Message, assistantEvent: AssistantMessageEvent)
+  case messageEnd(message: Message)
+
+  case toolExecutionStart(toolCallId: String, toolName: String, args: JSONValue)
+  case toolExecutionUpdate(toolCallId: String, toolName: String, args: JSONValue, partialResult: JSONValue)
+  case toolExecutionEnd(toolCallId: String, toolName: String, result: AgentToolResult, isError: Bool)
+}

--- a/Sources/PiAgent/AgentLoop.swift
+++ b/Sources/PiAgent/AgentLoop.swift
@@ -1,0 +1,365 @@
+import Foundation
+import PiAI
+
+public typealias StreamFn = @Sendable (Model, Context, RequestOptions) async throws
+  -> AsyncThrowingStream<AssistantMessageEvent, any Error>
+
+public struct AgentContext: Sendable {
+  public var systemPrompt: String
+  public var messages: [Message]
+  public var tools: [AnyAgentTool]
+
+  public init(systemPrompt: String, messages: [Message], tools: [AnyAgentTool] = []) {
+    self.systemPrompt = systemPrompt
+    self.messages = messages
+    self.tools = tools
+  }
+}
+
+public struct AgentLoopConfig: Sendable {
+  public var model: Model
+  public var requestOptions: RequestOptions
+
+  /// Safety valve for tests and defensive callers: stop after this many assistant turns.
+  ///
+  /// `nil` means unlimited.
+  public var maxTurns: Int?
+
+  public var transformContext: (@Sendable ([Message]) async throws -> [Message])?
+  public var getSteeringMessages: (@Sendable () async throws -> [Message])?
+  public var getFollowUpMessages: (@Sendable () async throws -> [Message])?
+
+  public var streamFn: StreamFn
+
+  public init(
+    model: Model,
+    requestOptions: RequestOptions = .init(),
+    maxTurns: Int? = nil,
+    transformContext: (@Sendable ([Message]) async throws -> [Message])? = nil,
+    getSteeringMessages: (@Sendable () async throws -> [Message])? = nil,
+    getFollowUpMessages: (@Sendable () async throws -> [Message])? = nil,
+    streamFn: @escaping StreamFn = PiAI.streamSimple,
+  ) {
+    self.model = model
+    self.requestOptions = requestOptions
+    self.maxTurns = maxTurns
+    self.transformContext = transformContext
+    self.getSteeringMessages = getSteeringMessages
+    self.getFollowUpMessages = getFollowUpMessages
+    self.streamFn = streamFn
+  }
+}
+
+public func agentLoop(
+  prompts: [Message],
+  context: AgentContext,
+  config: AgentLoopConfig,
+) -> AsyncThrowingStream<AgentEvent, any Error> {
+  makeAgentEventStream(prompts: prompts, context: context, config: config, mode: .start)
+}
+
+public enum AgentLoopContinueError: Error, Sendable, CustomStringConvertible {
+  case noMessages
+  case lastMessageIsAssistant
+
+  public var description: String {
+    switch self {
+    case .noMessages:
+      "Cannot continue: no messages in context"
+    case .lastMessageIsAssistant:
+      "Cannot continue from message role: assistant"
+    }
+  }
+}
+
+public func agentLoopContinue(
+  context: AgentContext,
+  config: AgentLoopConfig,
+) throws -> AsyncThrowingStream<AgentEvent, any Error> {
+  guard !context.messages.isEmpty else { throw AgentLoopContinueError.noMessages }
+  if case .assistant = context.messages.last { throw AgentLoopContinueError.lastMessageIsAssistant }
+  return makeAgentEventStream(prompts: [], context: context, config: config, mode: .continue)
+}
+
+enum AgentLoopMode {
+  case start
+  case `continue`
+}
+
+private func makeAgentEventStream(
+  prompts: [Message],
+  context: AgentContext,
+  config: AgentLoopConfig,
+  mode: AgentLoopMode,
+) -> AsyncThrowingStream<AgentEvent, any Error> {
+  AsyncThrowingStream(AgentEvent.self, bufferingPolicy: .bufferingNewest(1024)) { continuation in
+    let task = Task {
+      do {
+        try await runLoop(
+          prompts: prompts,
+          context: context,
+          config: config,
+          mode: mode,
+          emit: { continuation.yield($0) },
+        )
+      } catch {
+        continuation.finish(throwing: error)
+        return
+      }
+      continuation.finish()
+    }
+
+    continuation.onTermination = { _ in
+      task.cancel()
+    }
+  }
+}
+
+private func runLoop(
+  prompts: [Message],
+  context: AgentContext,
+  config: AgentLoopConfig,
+  mode: AgentLoopMode,
+  emit: @Sendable (AgentEvent) -> Void,
+) async throws {
+  var newMessages: [Message] = []
+  var currentContext = context
+  var firstTurn = true
+  var assistantTurnCount = 0
+
+  var pendingMessages: [Message] = try await (config.getSteeringMessages?() ?? [])
+
+  emit(.agentStart)
+  emit(.turnStart)
+
+  if mode == .start {
+    for prompt in prompts {
+      emit(.messageStart(message: prompt))
+      emit(.messageEnd(message: prompt))
+      currentContext.messages.append(prompt)
+      newMessages.append(prompt)
+    }
+  }
+
+  while true {
+    var hasMoreToolCalls = true
+    var steeringAfterTools: [Message]? = nil
+
+    while hasMoreToolCalls || !pendingMessages.isEmpty {
+      if !firstTurn {
+        emit(.turnStart)
+      } else {
+        firstTurn = false
+      }
+
+      if !pendingMessages.isEmpty {
+        for message in pendingMessages {
+          emit(.messageStart(message: message))
+          emit(.messageEnd(message: message))
+          currentContext.messages.append(message)
+          newMessages.append(message)
+        }
+        pendingMessages = []
+      }
+
+      assistantTurnCount += 1
+      if let maxTurns = config.maxTurns, assistantTurnCount > maxTurns {
+        throw PiAIError.unsupported("Agent loop exceeded maxTurns=\(maxTurns)")
+      }
+
+      let assistant = try await streamAssistantResponse(
+        context: currentContext,
+        config: config,
+        emit: emit,
+      )
+
+      currentContext.messages.append(.assistant(assistant))
+      newMessages.append(.assistant(assistant))
+
+      if assistant.stopReason == .error || assistant.stopReason == .aborted {
+        emit(.turnEnd(assistant: assistant, toolResults: []))
+        emit(.agentEnd(messages: newMessages))
+        return
+      }
+
+      let toolCalls = assistant.content.compactMap { block -> ToolCall? in
+        if case let .toolCall(call) = block { return call }
+        return nil
+      }
+      hasMoreToolCalls = !toolCalls.isEmpty
+
+      var toolResults: [ToolResultMessage] = []
+      if hasMoreToolCalls {
+        let toolExecution = try await executeToolCalls(
+          toolCalls: toolCalls,
+          tools: currentContext.tools,
+          emit: emit,
+          getSteeringMessages: config.getSteeringMessages,
+        )
+
+        toolResults.append(contentsOf: toolExecution.toolResults)
+        steeringAfterTools = toolExecution.steeringMessages
+
+        for result in toolResults {
+          let msg: Message = .toolResult(result)
+          currentContext.messages.append(msg)
+          newMessages.append(msg)
+        }
+      }
+
+      emit(.turnEnd(assistant: assistant, toolResults: toolResults))
+
+      if let steeringAfterTools, !steeringAfterTools.isEmpty {
+        pendingMessages = steeringAfterTools
+      } else {
+        pendingMessages = try await (config.getSteeringMessages?() ?? [])
+      }
+    }
+
+    let followUpMessages = try await (config.getFollowUpMessages?() ?? [])
+    if !followUpMessages.isEmpty {
+      pendingMessages = followUpMessages
+      continue
+    }
+
+    break
+  }
+
+  emit(.agentEnd(messages: newMessages))
+}
+
+private func streamAssistantResponse(
+  context: AgentContext,
+  config: AgentLoopConfig,
+  emit: @Sendable (AgentEvent) -> Void,
+) async throws -> AssistantMessage {
+  var messages = context.messages
+  if let transform = config.transformContext {
+    messages = try await transform(messages)
+  }
+
+  let llmContext = Context(
+    systemPrompt: context.systemPrompt.isEmpty ? nil : context.systemPrompt,
+    messages: messages,
+    tools: context.tools.map(\.tool),
+  )
+
+  let stream = try await config.streamFn(config.model, llmContext, config.requestOptions)
+
+  var partial: AssistantMessage?
+  var addedPartial = false
+  var final: AssistantMessage?
+
+  for try await event in stream {
+    switch event {
+    case let .start(p):
+      partial = p
+      addedPartial = true
+      emit(.messageStart(message: .assistant(p)))
+
+    case let .textDelta(delta: _, partial: p):
+      partial = p
+      emit(.messageUpdate(message: .assistant(p), assistantEvent: event))
+
+    case let .done(message):
+      if addedPartial == false {
+        emit(.messageStart(message: .assistant(message)))
+      }
+      emit(.messageEnd(message: .assistant(message)))
+      final = message
+    }
+  }
+
+  if let final { return final }
+  if let partial {
+    emit(.messageEnd(message: .assistant(partial)))
+    return partial
+  }
+
+  return AssistantMessage(provider: config.model.provider, model: config.model.id, stopReason: .error)
+}
+
+private func executeToolCalls(
+  toolCalls: [ToolCall],
+  tools: [AnyAgentTool],
+  emit: @Sendable (AgentEvent) -> Void,
+  getSteeringMessages: (@Sendable () async throws -> [Message])?,
+) async throws -> (toolResults: [ToolResultMessage], steeringMessages: [Message]?) {
+  var results: [ToolResultMessage] = []
+  var steeringMessages: [Message]? = nil
+
+  for (index, toolCall) in toolCalls.enumerated() {
+    emit(.toolExecutionStart(toolCallId: toolCall.id, toolName: toolCall.name, args: toolCall.arguments))
+
+    let tool = tools.first { $0.tool.name == toolCall.name }
+
+    var result: AgentToolResult
+    var isError = false
+
+    do {
+      guard let tool else { throw PiAIError.unsupported("Tool \(toolCall.name) not found") }
+      result = try await tool.execute(toolCallId: toolCall.id, args: toolCall.arguments)
+    } catch {
+      result = AgentToolResult(content: [.text(.init(text: String(describing: error)))], details: .object([:]))
+      isError = true
+    }
+
+    emit(.toolExecutionEnd(toolCallId: toolCall.id, toolName: toolCall.name, result: result, isError: isError))
+
+    let toolResultMessage = ToolResultMessage(
+      toolCallId: toolCall.id,
+      toolName: toolCall.name,
+      content: result.content,
+      details: result.details,
+      isError: isError,
+    )
+
+    results.append(toolResultMessage)
+    emit(.messageStart(message: .toolResult(toolResultMessage)))
+    emit(.messageEnd(message: .toolResult(toolResultMessage)))
+
+    if let getSteeringMessages {
+      let steering = try await getSteeringMessages()
+      if !steering.isEmpty {
+        steeringMessages = steering
+        if index + 1 < toolCalls.count {
+          for skipped in toolCalls[(index + 1)...] {
+            let skippedResult = ToolResultMessage(
+              toolCallId: skipped.id,
+              toolName: skipped.name,
+              content: [.text(.init(text: "Skipped due to queued user message."))],
+              details: .object([:]),
+              isError: true,
+            )
+            emit(.toolExecutionStart(toolCallId: skipped.id, toolName: skipped.name, args: skipped.arguments))
+            emit(.toolExecutionEnd(
+              toolCallId: skipped.id,
+              toolName: skipped.name,
+              result: .init(content: skippedResult.content, details: skippedResult.details),
+              isError: true,
+            ))
+            results.append(skippedResult)
+            emit(.messageStart(message: .toolResult(skippedResult)))
+            emit(.messageEnd(message: .toolResult(skippedResult)))
+          }
+        }
+        break
+      }
+    }
+  }
+
+  return (results, steeringMessages)
+}
+
+@_spi(Testing) public func executeToolCallsForTesting(
+  toolCalls: [ToolCall],
+  tools: [AnyAgentTool],
+  getSteeringMessages: (@Sendable () async throws -> [Message])? = nil,
+) async throws -> (toolResults: [ToolResultMessage], steeringMessages: [Message]?) {
+  try await executeToolCalls(
+    toolCalls: toolCalls,
+    tools: tools,
+    emit: { _ in },
+    getSteeringMessages: getSteeringMessages,
+  )
+}

--- a/Sources/PiAgent/AgentTool.swift
+++ b/Sources/PiAgent/AgentTool.swift
@@ -1,0 +1,54 @@
+import Foundation
+import PiAI
+
+public struct AgentToolResult: Sendable, Hashable {
+  public var content: [ContentBlock]
+  public var details: JSONValue
+
+  public init(content: [ContentBlock], details: JSONValue = .object([:])) {
+    self.content = content
+    self.details = details
+  }
+}
+
+public struct AnyAgentTool: Sendable {
+  public var tool: Tool
+  public var label: String
+
+  private let _execute: @Sendable (String, JSONValue) async throws -> AgentToolResult
+
+  public init(
+    tool: Tool,
+    label: String,
+    execute: @escaping @Sendable (String, JSONValue) async throws -> AgentToolResult,
+  ) {
+    self.tool = tool
+    self.label = label
+    _execute = execute
+  }
+
+  public func execute(toolCallId: String, args: JSONValue) async throws -> AgentToolResult {
+    try await _execute(toolCallId, args)
+  }
+}
+
+public extension AnyAgentTool {
+  init<Parameters: Decodable & Sendable>(
+    name: String,
+    label: String,
+    description: String,
+    parametersSchema: JSONValue,
+    execute: @escaping @Sendable (String, Parameters) async throws -> AgentToolResult,
+  ) {
+    let tool = Tool(name: name, description: description, parameters: parametersSchema)
+    self.init(tool: tool, label: label) { toolCallId, args in
+      let params = try decode(Parameters.self, from: args)
+      return try await execute(toolCallId, params)
+    }
+  }
+}
+
+private func decode<T: Decodable>(_: T.Type, from value: JSONValue) throws -> T {
+  let data = try JSONSerialization.data(withJSONObject: value.toAny())
+  return try JSONDecoder().decode(T.self, from: data)
+}

--- a/Sources/PiAgent/PiAgent.docc/PiAgent.md
+++ b/Sources/PiAgent/PiAgent.docc/PiAgent.md
@@ -1,0 +1,52 @@
+# ``PiAgent``
+
+Minimal agent-loop primitives built on top of ``PiAI``.
+
+## Overview
+
+`PiAgent` provides:
+
+- An agent loop (`agentLoop`, `agentLoopContinue`) that repeatedly calls an LLM and executes tool calls.
+- A Swift Concurrency–native ``Agent`` actor that exposes an `AsyncSequence` of ``AgentEvent`` via ``Agent/events``.
+
+This is intentionally small and terminal-friendly: no UI framework, no thread primitives, and no subscription callbacks.
+
+## Basic usage
+
+```swift
+import PiAI
+import PiAgent
+
+let tool = AnyAgentTool(
+  tool: Tool(
+    name: "weather",
+    description: "Get the weather for a city",
+    parameters: .object([
+      "type": .string("object"),
+      "properties": .object([
+        "city": .object(["type": .string("string")]),
+      ]),
+      "required": .array([.string("city")]),
+    ])
+  ),
+  label: "Weather",
+  execute: { _, args in
+    let city = (args.object?["city"]?.stringValue) ?? "Unknown"
+    return AgentToolResult(content: [.text("Sunny in \\(city)")])
+  }
+)
+
+let agent = Agent(opts: .init(initialState: .init(
+  systemPrompt: "You are a helpful assistant.",
+  model: Model(id: "gpt-4.1-mini", provider: .openai),
+  tools: [tool]
+)))
+
+Task {
+  for await event in agent.events {
+    print(event)
+  }
+}
+
+try await agent.prompt("What's the weather in San Francisco?")
+```

--- a/Sources/wuhu/main.swift
+++ b/Sources/wuhu/main.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 import Foundation
 import GRDB
+import PiAgent
 import PiAI
 
 @inline(never)
@@ -13,7 +14,7 @@ struct Wuhu: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "wuhu",
     abstract: "Wuhu (Swift) – small demo CLI for PiAI providers.",
-    subcommands: [OpenAI.self, Anthropic.self],
+    subcommands: [OpenAI.self, Anthropic.self, Agent.self],
   )
 
   struct Shared: ParsableArguments {
@@ -43,7 +44,7 @@ struct Wuhu: AsyncParsableCommand {
       let provider = OpenAIResponsesProvider()
       let model = Model(id: model, provider: .openai)
       let context = Context(systemPrompt: "You are a helpful assistant.", messages: [
-        ChatMessage(role: .user, content: prompt),
+        .user(prompt),
       ])
 
       for try await event in try await provider.stream(model: model, context: context) {
@@ -81,7 +82,7 @@ struct Wuhu: AsyncParsableCommand {
       let provider = AnthropicMessagesProvider()
       let model = Model(id: model, provider: .anthropic)
       let context = Context(systemPrompt: "You are a helpful assistant.", messages: [
-        ChatMessage(role: .user, content: prompt),
+        .user(prompt),
       ])
 
       for try await event in try await provider.stream(model: model, context: context) {
@@ -94,6 +95,125 @@ struct Wuhu: AsyncParsableCommand {
           FileHandle.standardOutput.write(Data("\n".utf8))
         }
       }
+    }
+  }
+
+  struct Agent: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "agent",
+      abstract: "Run a minimal tool-using agent loop (stdin → tools → final response).",
+      subcommands: [OpenAI.self, Anthropic.self],
+    )
+
+    struct SharedAgent: ParsableArguments {
+      @Option(help: "Path to a .env file to load (default: ./.env if present).")
+      var envFile: String?
+
+      @Option(help: "Max assistant turns (safety valve).")
+      var maxTurns: Int = 12
+    }
+
+    struct OpenAI: AsyncParsableCommand {
+      static let configuration = CommandConfiguration(
+        commandName: "openai",
+        abstract: "Agent loop via OpenAI Responses API.",
+      )
+
+      @Option(help: "OpenAI model id.")
+      var model: String = "gpt-4.1-mini"
+
+      @OptionGroup
+      var shared: SharedAgent
+
+      func run() async throws {
+        try await runAgent(provider: .openai, modelId: model, shared: shared)
+      }
+    }
+
+    struct Anthropic: AsyncParsableCommand {
+      static let configuration = CommandConfiguration(
+        commandName: "anthropic",
+        abstract: "Agent loop via Anthropic Messages API.",
+      )
+
+      @Option(help: "Anthropic model id.")
+      var model: String = "claude-sonnet-4-5"
+
+      @OptionGroup
+      var shared: SharedAgent
+
+      func run() async throws {
+        try await runAgent(provider: .anthropic, modelId: model, shared: shared)
+      }
+    }
+
+    private static func runAgent(provider: Provider, modelId: String, shared: SharedAgent) async throws {
+      _ensureGRDBIsLinked()
+      try DotEnv.loadIfPresent(path: shared.envFile)
+
+      let prompt = readAllStdin().trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !prompt.isEmpty else {
+        throw ValidationError("Expected a prompt on stdin.")
+      }
+
+      let tool = makeSimulatedWeatherTool()
+      let model = Model(id: modelId, provider: provider)
+
+      let agent = PiAgent.Agent(opts: .init(
+        initialState: .init(
+          systemPrompt: [
+            "You are a terminal agent.",
+            "You have a weather tool. Always call it when asked about weather, and prefer tool results over guesses.",
+            "If asked to compare cities, call the tool for each city and compare temperatures.",
+          ].joined(separator: "\n"),
+          model: model,
+          tools: [tool],
+        ),
+        maxTurns: shared.maxTurns,
+      ))
+
+      let eventsTask = Task {
+        var printedStreamingText = false
+        do {
+          for try await event in agent.events {
+            switch event {
+            case let .toolExecutionStart(_, toolName, args):
+              FileHandle.standardError.write(Data("\n[tool] \(toolName) args=\(formatJSON(args))\n".utf8))
+            case let .messageUpdate(message, assistantEvent):
+              if case .assistant = message, case let .textDelta(delta, _) = assistantEvent {
+                printedStreamingText = true
+                FileHandle.standardOutput.write(Data(delta.utf8))
+              }
+            case let .messageEnd(message):
+              if case let .assistant(m) = message, printedStreamingText == false {
+                let text = m.content.compactMap { block -> String? in
+                  if case let .text(part) = block { return part.text }
+                  return nil
+                }.joined()
+                if !text.isEmpty {
+                  FileHandle.standardOutput.write(Data(text.utf8))
+                }
+              }
+              if case .assistant = message {
+                FileHandle.standardOutput.write(Data("\n".utf8))
+                printedStreamingText = false
+              }
+            default:
+              continue
+            }
+          }
+        } catch {
+          // Ignore cancellation and surface other errors as best-effort stderr output.
+          if (error as? CancellationError) == nil {
+            FileHandle.standardError.write(Data("\n[agent events error] \(String(describing: error))\n".utf8))
+          }
+        }
+      }
+
+      defer { eventsTask.cancel() }
+
+      try await agent.prompt(prompt)
+      await agent.waitForIdle()
     }
   }
 }
@@ -124,4 +244,92 @@ enum DotEnv {
       }
     }
   }
+}
+
+private func readAllStdin() -> String {
+  let data = FileHandle.standardInput.readDataToEndOfFile()
+  return String(decoding: data, as: UTF8.self)
+}
+
+private func makeSimulatedWeatherTool() -> AnyAgentTool {
+  struct Params: Decodable, Sendable {
+    var city: String
+  }
+
+  let schema: JSONValue = .object([
+    "type": .string("object"),
+    "properties": .object([
+      "city": .object([
+        "type": .string("string"),
+        "description": .string("City name, e.g. San Francisco"),
+      ]),
+    ]),
+    "required": .array([.string("city")]),
+    "additionalProperties": .bool(false),
+  ])
+
+  return AnyAgentTool(
+    name: "weather",
+    label: "Weather",
+    description: "Get simulated weather data for a city (demo tool; returns fake data).",
+    parametersSchema: schema,
+    execute: { (_: String, params: Params) in
+      let report = simulatedWeather(for: params.city)
+      let text = "\(report.city): \(report.temperatureC)°C, \(report.condition) (simulated)"
+      return AgentToolResult(
+        content: [.text(text)],
+        details: .object([
+          "city": .string(report.city),
+          "temperatureC": .number(Double(report.temperatureC)),
+          "condition": .string(report.condition),
+          "source": .string("simulated"),
+        ]),
+      )
+    },
+  )
+}
+
+private struct WeatherReport: Sendable {
+  var city: String
+  var temperatureC: Int
+  var condition: String
+}
+
+private func simulatedWeather(for cityRaw: String) -> WeatherReport {
+  let city = cityRaw.trimmingCharacters(in: .whitespacesAndNewlines)
+  let normalized = city.lowercased()
+
+  // Deterministic "fake" data: stable enough for demos/tests.
+  let fixed: [String: WeatherReport] = [
+    "san francisco": .init(city: "San Francisco", temperatureC: 18, condition: "foggy"),
+    "san diego": .init(city: "San Diego", temperatureC: 24, condition: "sunny"),
+    "tokyo": .init(city: "Tokyo", temperatureC: 29, condition: "humid"),
+    "new york": .init(city: "New York", temperatureC: 6, condition: "windy"),
+  ]
+  if let report = fixed[normalized] { return report }
+
+  let hash = stableHash(normalized)
+  let temp = 5 + Int(hash % 26) // 5..30
+  let conditions = ["sunny", "cloudy", "rainy", "windy", "foggy"]
+  let condition = conditions[Int((hash / 31) % UInt64(conditions.count))]
+  return .init(city: city.isEmpty ? "Unknown" : city, temperatureC: temp, condition: condition)
+}
+
+private func stableHash(_ s: String) -> UInt64 {
+  // FNV-1a 64-bit
+  var hash: UInt64 = 14_695_981_039_346_656_037
+  for b in s.utf8 {
+    hash ^= UInt64(b)
+    hash &*= 1_099_511_628_211
+  }
+  return hash
+}
+
+private func formatJSON(_ value: JSONValue) -> String {
+  if let data = try? JSONSerialization.data(withJSONObject: value.toAny(), options: [.sortedKeys]),
+     let s = String(data: data, encoding: .utf8)
+  {
+    return s
+  }
+  return "{}"
 }

--- a/Tests/PiAITests/AnthropicMessagesProviderTests.swift
+++ b/Tests/PiAITests/AnthropicMessagesProviderTests.swift
@@ -22,7 +22,7 @@ struct AnthropicMessagesProviderTests {
     let provider = AnthropicMessagesProvider(http: http)
     let model = Model(id: "claude-sonnet-4-5", provider: .anthropic)
     let context = Context(systemPrompt: "You are a helpful assistant.", messages: [
-      ChatMessage(role: .user, content: "Say hello"),
+      .user("Say hello"),
     ])
 
     let stream = try await provider.stream(model: model, context: context, options: .init(apiKey: apiKey))

--- a/Tests/PiAITests/LiveProvidersE2ETests.swift
+++ b/Tests/PiAITests/LiveProvidersE2ETests.swift
@@ -10,7 +10,7 @@ struct LiveProvidersE2ETests {
     let provider = OpenAIResponsesProvider()
     let model = Model(id: "gpt-4.1-mini", provider: .openai)
     let context = Context(systemPrompt: "Follow instructions exactly.", messages: [
-      ChatMessage(role: .user, content: "Output exactly: HELLO"),
+      .user("Output exactly: HELLO"),
     ])
 
     let stream = try await provider.stream(
@@ -38,7 +38,7 @@ struct LiveProvidersE2ETests {
     let provider = AnthropicMessagesProvider()
     let model = Model(id: "claude-sonnet-4-5", provider: .anthropic)
     let context = Context(systemPrompt: "Follow instructions exactly.", messages: [
-      ChatMessage(role: .user, content: "Output exactly: HELLO"),
+      .user("Output exactly: HELLO"),
     ])
 
     let stream = try await provider.stream(

--- a/Tests/PiAITests/OpenAICodexResponsesProviderTests.swift
+++ b/Tests/PiAITests/OpenAICodexResponsesProviderTests.swift
@@ -29,7 +29,7 @@ struct OpenAICodexResponsesProviderTests {
     let provider = OpenAICodexResponsesProvider(http: http)
     let model = Model(id: "gpt-5.1-codex", provider: .openaiCodex)
     let context = Context(systemPrompt: "You are a helpful assistant.", messages: [
-      ChatMessage(role: .user, content: "Say hello"),
+      .user("Say hello"),
     ])
 
     let stream = try await provider.stream(model: model, context: context, options: .init(apiKey: token))
@@ -77,7 +77,7 @@ struct OpenAICodexResponsesProviderTests {
     let provider = OpenAICodexResponsesProvider(http: http)
     let model = Model(id: "gpt-5.1-codex", provider: .openaiCodex)
     let context = Context(systemPrompt: "You are a helpful assistant.", messages: [
-      ChatMessage(role: .user, content: "Say hello"),
+      .user("Say hello"),
     ])
 
     _ = try await provider.stream(

--- a/Tests/PiAITests/OpenAIResponsesProviderTests.swift
+++ b/Tests/PiAITests/OpenAIResponsesProviderTests.swift
@@ -23,7 +23,7 @@ struct OpenAIResponsesProviderTests {
     let provider = OpenAIResponsesProvider(http: http)
     let model = Model(id: "gpt-4.1-mini", provider: .openai)
     let context = Context(systemPrompt: "You are a helpful assistant.", messages: [
-      ChatMessage(role: .user, content: "Say hello"),
+      .user("Say hello"),
     ])
 
     let stream = try await provider.stream(model: model, context: context, options: .init(apiKey: apiKey))

--- a/Tests/PiAgentTests/AgentLoopTests.swift
+++ b/Tests/PiAgentTests/AgentLoopTests.swift
@@ -1,0 +1,240 @@
+import Foundation
+import PiAI
+@_spi(Testing) import PiAgent
+import Testing
+
+struct AgentLoopTests {
+  @Test func emitsLifecycleEventsAndReturnsMessages() async throws {
+    let context = AgentContext(systemPrompt: "You are helpful.", messages: [], tools: [])
+    let config = AgentLoopConfig(
+      model: .init(id: "mock", provider: .openai),
+      requestOptions: .init(),
+      maxTurns: 2,
+      streamFn: { model, _, _ in
+        AsyncThrowingStream<AssistantMessageEvent, any Error> { continuation in
+          Task {
+            let message = AssistantMessage(
+              provider: model.provider,
+              model: model.id,
+              content: [.text("Hi there!")],
+              stopReason: .stop,
+            )
+            continuation.yield(.done(message: message))
+            continuation.finish()
+          }
+        }
+      },
+    )
+
+    let prompt: [Message] = [.user("Hello")]
+
+    var sawAgentStart = false
+    var sawAgentEnd = false
+    var sawTurnStart = false
+    var sawTurnEnd = false
+    var endedMessages: [Message] = []
+
+    let stream = agentLoop(prompts: prompt, context: context, config: config)
+    for try await event in stream {
+      switch event {
+      case .agentStart:
+        sawAgentStart = true
+      case let .agentEnd(messages):
+        sawAgentEnd = true
+        endedMessages = messages
+      case .turnStart:
+        sawTurnStart = true
+      case .turnEnd:
+        sawTurnEnd = true
+      default:
+        break
+      }
+    }
+
+    #expect(sawAgentStart)
+    #expect(sawTurnStart)
+    #expect(sawTurnEnd)
+    #expect(sawAgentEnd)
+
+    #expect(endedMessages.count == 2)
+    if case .user = endedMessages[0] {} else { #expect(Bool(false)) }
+    if case .assistant = endedMessages[1] {} else { #expect(Bool(false)) }
+  }
+
+  @Test func handlesToolCallsAndResults() async throws {
+    actor Strings {
+      var values: [String] = []
+      func append(_ value: String) {
+        values.append(value)
+      }
+
+      func snapshot() -> [String] {
+        values
+      }
+    }
+
+    let executed = Strings()
+
+    let tool = AnyAgentTool(
+      tool: Tool(
+        name: "echo",
+        description: "Echo tool",
+        parameters: .object([
+          "type": .string("object"),
+          "properties": .object([
+            "value": .object(["type": .string("string")]),
+          ]),
+          "required": .array([.string("value")]),
+        ]),
+      ),
+      label: "Echo",
+      execute: { _, args in
+        let value = args.object?["value"]?.stringValue ?? ""
+        await executed.append(value)
+        return AgentToolResult(content: [.text("echoed: \(value)")], details: .object(["value": .string(value)]))
+      },
+    )
+
+    let context = AgentContext(systemPrompt: "", messages: [], tools: [tool])
+
+    let config = AgentLoopConfig(
+      model: .init(id: "mock", provider: .openai),
+      requestOptions: .init(),
+      maxTurns: 4,
+      streamFn: { model, ctx, _ in
+        let hasToolResult = ctx.messages.contains(where: { msg in
+          if case .toolResult = msg { return true }
+          return false
+        })
+        return AsyncThrowingStream<AssistantMessageEvent, any Error> { continuation in
+          Task {
+            if hasToolResult == false {
+              let toolCall = ToolCall(id: "tool-1", name: "echo", arguments: .object(["value": .string("hello")]))
+              let assistant = AssistantMessage(
+                provider: model.provider,
+                model: model.id,
+                content: [.toolCall(toolCall)],
+                stopReason: .toolUse,
+              )
+              continuation.yield(.done(message: assistant))
+            } else {
+              let assistant = AssistantMessage(
+                provider: model.provider,
+                model: model.id,
+                content: [.text("done")],
+                stopReason: .stop,
+              )
+              continuation.yield(.done(message: assistant))
+            }
+            continuation.finish()
+          }
+        }
+      },
+    )
+
+    let stream = agentLoop(prompts: [.user("echo something")], context: context, config: config)
+    var sawToolStart = false
+    var sawToolEnd = false
+
+    for try await event in stream {
+      switch event {
+      case .toolExecutionStart:
+        sawToolStart = true
+      case let .toolExecutionEnd(_, _, _, isError):
+        sawToolEnd = true
+        #expect(isError == false)
+      default:
+        break
+      }
+    }
+
+    #expect(sawToolStart)
+    #expect(sawToolEnd)
+    #expect(await executed.snapshot() == ["hello"])
+  }
+
+  @Test func injectsSteeringMessagesAndSkipsRemainingTools() async throws {
+    actor Strings {
+      var values: [String] = []
+      func append(_ value: String) {
+        values.append(value)
+      }
+
+      func snapshot() -> [String] {
+        values
+      }
+
+      func count() -> Int {
+        values.count
+      }
+    }
+
+    let executed = Strings()
+    let queuedUserMessage: Message = .user("interrupt")
+
+    let tool = AnyAgentTool(
+      tool: Tool(
+        name: "echo",
+        description: "Echo tool",
+        parameters: .object([
+          "type": .string("object"),
+          "properties": .object([
+            "value": .object(["type": .string("string")]),
+          ]),
+          "required": .array([.string("value")]),
+        ]),
+      ),
+      label: "Echo",
+      execute: { _, args in
+        let value = args.object?["value"]?.stringValue ?? ""
+        await executed.append(value)
+        return AgentToolResult(content: [.text("ok:\(value)")])
+      },
+    )
+
+    let toolCalls: [ToolCall] = [
+      .init(id: "tool-1", name: "echo", arguments: .object(["value": .string("first")])),
+      .init(id: "tool-2", name: "echo", arguments: .object(["value": .string("second")])),
+    ]
+
+    actor Steering {
+      var sent = false
+      func nextMessages(executedCount: Int, message: Message) -> [Message] {
+        guard executedCount == 1, sent == false else { return [] }
+        sent = true
+        return [message]
+      }
+    }
+    let steering = Steering()
+
+    let result = try await executeToolCallsForTesting(
+      toolCalls: toolCalls,
+      tools: [tool],
+      getSteeringMessages: {
+        let count = await executed.count()
+        return await steering.nextMessages(executedCount: count, message: queuedUserMessage)
+      },
+    )
+
+    #expect(await executed.snapshot() == ["first"])
+    #expect(result.toolResults.count == 2)
+    #expect(result.toolResults[0].isError == false)
+    #expect(result.toolResults[1].isError == true)
+    #expect(result.steeringMessages?.count == 1)
+
+    let skippedText = result.toolResults[1].content.compactMap { block -> String? in
+      if case let .text(part) = block { return part.text }
+      return nil
+    }.joined(separator: "\n")
+    #expect(skippedText.contains("Skipped due to queued user message"))
+  }
+
+  @Test func continueThrowsOnEmptyContext() throws {
+    let context = AgentContext(systemPrompt: "You are helpful.", messages: [], tools: [])
+    let config = AgentLoopConfig(model: .init(id: "mock", provider: .openai))
+
+    #expect(throws: AgentLoopContinueError.self) {
+      _ = try agentLoopContinue(context: context, config: config)
+    }
+  }
+}

--- a/Tests/PiAgentTests/AgentTests.swift
+++ b/Tests/PiAgentTests/AgentTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import PiAgent
+import PiAI
+import Testing
+
+struct AgentTests {
+  @Test func createsAgentWithDefaultState() async {
+    let agent = Agent(opts: .init())
+    let state = await agent.state
+    #expect(state.systemPrompt == "")
+    #expect(state.messages.isEmpty)
+    #expect(state.tools.isEmpty)
+    #expect(state.isStreaming == false)
+  }
+
+  @Test func stateMutatorsUpdateState() async {
+    let agent = Agent(opts: .init())
+    await agent.setSystemPrompt("You are a helpful assistant.")
+    await agent.setModel(.init(id: "mock", provider: .openai))
+
+    let tool = AnyAgentTool(
+      tool: .init(
+        name: "noop",
+        description: "No-op",
+        parameters: .object(["type": .string("object")]),
+      ),
+      label: "No-op",
+      execute: { _, _ in .init(content: [.text("ok")]) },
+    )
+    await agent.setTools([tool])
+    await agent.replaceMessages([.user("Hello")])
+
+    let state = await agent.state
+    #expect(state.systemPrompt == "You are a helpful assistant.")
+    #expect(state.model.id == "mock")
+    #expect(state.tools.count == 1)
+    #expect(state.messages.count == 1)
+  }
+
+  @Test func promptThrowsWhileStreaming() async throws {
+    let agent = Agent(opts: .init(streamFn: { model, _, _ in
+      AsyncThrowingStream<AssistantMessageEvent, any Error> { continuation in
+        Task {
+          let partial = AssistantMessage(provider: model.provider, model: model.id)
+          continuation.yield(.start(partial: partial))
+          try? await Task.sleep(nanoseconds: 300_000_000) // 300ms
+          let done = AssistantMessage(provider: model.provider, model: model.id, content: [.text("ok")])
+          continuation.yield(.done(message: done))
+          continuation.finish()
+        }
+      }
+    }))
+
+    let running = Task {
+      try await agent.prompt("First")
+    }
+
+    try await Task.sleep(nanoseconds: 30_000_000) // 30ms
+    let isStreaming = await agent.state.isStreaming
+    #expect(isStreaming == true)
+
+    do {
+      try await agent.prompt("Second")
+      #expect(Bool(false))
+    } catch {
+      #expect(Bool(true))
+    }
+
+    _ = try? await running.value
+    await agent.waitForIdle()
+    #expect(await agent.state.isStreaming == false)
+  }
+}


### PR DESCRIPTION
Ports pi-agent to Swift as new PiAgent target (async-sequence events + actor Agent). Extends PiAI tool calling across OpenAI Responses and Anthropic Messages, and adds a minimal `wuhu agent` terminal demo with a simulated weather tool.

Manual verify (local): ran the multi-tool prompt against both OpenAI and Anthropic backends; observed SF+SD tool calls then Tokyo follow-up when SD hotter.

Adds PiAgentTests (swift-testing) and updates PiAITests for tool-call parsing.