### PR TITLE
Persisted agent sessions in SQLite (GRDB)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,7 @@ let package = Package(
   products: [
     .library(name: "PiAI", targets: ["PiAI"]),
     .library(name: "PiAgent", targets: ["PiAgent"]),
+    .library(name: "WuhuCore", targets: ["WuhuCore"]),
     .executable(name: "wuhu", targets: ["wuhu"]),
   ],
   dependencies: [
@@ -48,13 +49,20 @@ let package = Package(
       ],
       swiftSettings: strictConcurrency,
     ),
-    .executableTarget(
-      name: "wuhu",
+    .target(
+      name: "WuhuCore",
       dependencies: [
         "PiAI",
         "PiAgent",
-        .product(name: "ArgumentParser", package: "swift-argument-parser"),
         .product(name: "GRDB", package: "GRDB.swift"),
+      ],
+      swiftSettings: strictConcurrency,
+    ),
+    .executableTarget(
+      name: "wuhu",
+      dependencies: [
+        "WuhuCore",
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ],
       swiftSettings: strictConcurrency,
     ),
@@ -70,6 +78,14 @@ let package = Package(
       name: "PiAgentTests",
       dependencies: [
         "PiAgent",
+        .product(name: "Testing", package: "swift-testing"),
+      ],
+      swiftSettings: strictConcurrency,
+    ),
+    .testTarget(
+      name: "WuhuCoreTests",
+      dependencies: [
+        "WuhuCore",
         .product(name: "Testing", package: "swift-testing"),
       ],
       swiftSettings: strictConcurrency,

--- a/README.md
+++ b/README.md
@@ -6,8 +6,18 @@ Swift 6.2 pivot of Wuhu.
 
 ```bash
 swift run wuhu --help
-swift run wuhu openai "Say hello"
-swift run wuhu anthropic "Say hello"
+
+# Create a persisted session (prints session id)
+swift run wuhu create-session --provider openai
+
+# Send a prompt to an existing session (streams assistant output)
+swift run wuhu prompt --session-id <session-id> "What's the weather in Tokyo?"
+
+# Retrieve full transcript
+swift run wuhu get-session --session-id <session-id>
+
+# List sessions
+swift run wuhu list-sessions
 ```
 
 The CLI reads `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` from the environment and will also load a local `.env` if present.

--- a/Sources/WuhuCore/Exports.swift
+++ b/Sources/WuhuCore/Exports.swift
@@ -1,0 +1,2 @@
+@_exported import PiAgent
+@_exported import PiAI

--- a/Sources/WuhuCore/SQLiteSessionStore.swift
+++ b/Sources/WuhuCore/SQLiteSessionStore.swift
@@ -1,0 +1,306 @@
+import Foundation
+import GRDB
+import PiAI
+
+public actor SQLiteSessionStore: SessionStore {
+  private let dbQueue: DatabaseQueue
+
+  public init(path: String) throws {
+    var config = Configuration()
+    config.foreignKeysEnabled = true
+    config.busyMode = .timeout(5)
+
+    dbQueue = try DatabaseQueue(path: path, configuration: config)
+    try Self.migrator.migrate(dbQueue)
+  }
+
+  public func createSession(
+    provider: WuhuProvider,
+    model: String,
+    systemPrompt: String,
+    cwd: String,
+    parentSessionID: String?,
+  ) async throws -> WuhuSession {
+    let now = Date()
+    let sessionID = UUID().uuidString.lowercased()
+
+    return try await dbQueue.write { db in
+      var sessionRow = SessionRow(
+        id: sessionID,
+        provider: provider.rawValue,
+        model: model,
+        cwd: cwd,
+        parentSessionID: parentSessionID,
+        createdAt: now,
+        updatedAt: now,
+        headEntryID: nil,
+        tailEntryID: nil,
+      )
+      try sessionRow.insert(db)
+
+      let headerPayload = WuhuEntryPayload.header(.init(systemPrompt: systemPrompt))
+      var headerRow = try EntryRow.new(
+        sessionID: sessionID,
+        parentEntryID: nil,
+        payload: headerPayload,
+        createdAt: now,
+      )
+      try headerRow.insert(db)
+      guard let headerID = headerRow.id else {
+        throw WuhuStoreError.sessionCorrupt("Failed to create header entry id")
+      }
+
+      sessionRow.headEntryID = headerID
+      sessionRow.tailEntryID = headerID
+      try sessionRow.update(db)
+
+      return try sessionRow.toModel()
+    }
+  }
+
+  public func getSession(id: String) async throws -> WuhuSession {
+    try await dbQueue.read { db in
+      guard let row = try SessionRow.fetchOne(db, key: id) else {
+        throw WuhuStoreError.sessionNotFound(id)
+      }
+      return try row.toModel()
+    }
+  }
+
+  public func listSessions(limit: Int? = nil) async throws -> [WuhuSession] {
+    try await dbQueue.read { db in
+      var req = SessionRow.order(Column("updatedAt").desc)
+      if let limit { req = req.limit(limit) }
+      return try req.fetchAll(db).map { try $0.toModel() }
+    }
+  }
+
+  @discardableResult
+  public func appendEntry(sessionID: String, payload: WuhuEntryPayload) async throws -> WuhuSessionEntry {
+    let now = Date()
+    return try await dbQueue.write { db in
+      guard var session = try SessionRow.fetchOne(db, key: sessionID) else {
+        throw WuhuStoreError.sessionNotFound(sessionID)
+      }
+      guard let tailID = session.tailEntryID else {
+        throw WuhuStoreError.sessionCorrupt("Session \(sessionID) missing tailEntryID")
+      }
+
+      var row = try EntryRow.new(
+        sessionID: sessionID,
+        parentEntryID: tailID,
+        payload: payload,
+        createdAt: now,
+      )
+      try row.insert(db)
+      guard let newID = row.id else {
+        throw WuhuStoreError.sessionCorrupt("Failed to create entry id")
+      }
+
+      session.tailEntryID = newID
+      session.updatedAt = now
+      try session.update(db)
+
+      return row.toModel()
+    }
+  }
+
+  public func getEntries(sessionID: String) async throws -> [WuhuSessionEntry] {
+    try await dbQueue.read { db in
+      guard let sessionRow = try SessionRow.fetchOne(db, key: sessionID) else {
+        throw WuhuStoreError.sessionNotFound(sessionID)
+      }
+      let session = try sessionRow.toModel()
+      let rows = try EntryRow
+        .filter(Column("sessionID") == sessionID)
+        .fetchAll(db)
+      let entries = rows.map { $0.toModel() }
+      return try Self.linearize(
+        entries: entries,
+        sessionID: sessionID,
+        headEntryID: session.headEntryID,
+        tailEntryID: session.tailEntryID,
+      )
+    }
+  }
+
+  private static func linearize(
+    entries: [WuhuSessionEntry],
+    sessionID: String,
+    headEntryID: Int64,
+    tailEntryID: Int64,
+  ) throws -> [WuhuSessionEntry] {
+    var byID: [Int64: WuhuSessionEntry] = [:]
+    byID.reserveCapacity(entries.count)
+
+    var childByParent: [Int64: WuhuSessionEntry] = [:]
+    childByParent.reserveCapacity(entries.count)
+
+    var header: WuhuSessionEntry?
+    for entry in entries {
+      byID[entry.id] = entry
+      if let parent = entry.parentEntryID {
+        childByParent[parent] = entry
+      } else {
+        header = entry
+      }
+    }
+
+    guard let header else { throw WuhuStoreError.noHeaderEntry(sessionID) }
+    guard header.id == headEntryID else {
+      throw WuhuStoreError.sessionCorrupt("headEntryID=\(headEntryID) does not match header.id=\(header.id)")
+    }
+
+    var ordered: [WuhuSessionEntry] = []
+    ordered.reserveCapacity(entries.count)
+
+    var current = header
+    ordered.append(current)
+    var seen = Set<Int64>()
+    seen.insert(current.id)
+
+    while let child = childByParent[current.id] {
+      if seen.contains(child.id) {
+        throw WuhuStoreError.sessionCorrupt("Cycle detected at entry \(child.id)")
+      }
+      ordered.append(child)
+      seen.insert(child.id)
+      current = child
+    }
+
+    guard current.id == tailEntryID else {
+      throw WuhuStoreError.sessionCorrupt("tailEntryID=\(tailEntryID) does not match last.id=\(current.id)")
+    }
+
+    if ordered.count != entries.count {
+      throw WuhuStoreError.sessionCorrupt("Entries are not a single linear chain (expected \(entries.count), got \(ordered.count))")
+    }
+
+    return ordered
+  }
+}
+
+private struct SessionRow: Codable, FetchableRecord, MutablePersistableRecord {
+  static let databaseTableName = "sessions"
+
+  var id: String
+  var provider: String
+  var model: String
+  var cwd: String
+  var parentSessionID: String?
+  var createdAt: Date
+  var updatedAt: Date
+  var headEntryID: Int64?
+  var tailEntryID: Int64?
+
+  func toModel() throws -> WuhuSession {
+    guard let provider = WuhuProvider(rawValue: provider) else {
+      throw WuhuStoreError.sessionCorrupt("Unknown provider: \(self.provider)")
+    }
+    guard let headEntryID, let tailEntryID else {
+      throw WuhuStoreError.sessionCorrupt("Session \(id) missing head/tail entry ids")
+    }
+    return .init(
+      id: id,
+      provider: provider,
+      model: model,
+      cwd: cwd,
+      parentSessionID: parentSessionID,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      headEntryID: headEntryID,
+      tailEntryID: tailEntryID,
+    )
+  }
+}
+
+private struct EntryRow: Codable, FetchableRecord, MutablePersistableRecord {
+  static let databaseTableName = "session_entries"
+
+  var id: Int64?
+  var sessionID: String
+  var parentEntryID: Int64?
+  var type: String
+  var payload: Data
+  var createdAt: Date
+
+  mutating func didInsert(_ inserted: InsertionSuccess) {
+    id = inserted.rowID
+  }
+
+  static func new(
+    sessionID: String,
+    parentEntryID: Int64?,
+    payload: WuhuEntryPayload,
+    createdAt: Date,
+  ) throws -> EntryRow {
+    let encoded = try WuhuJSON.encoder.encode(payload)
+    return .init(
+      id: nil,
+      sessionID: sessionID,
+      parentEntryID: parentEntryID,
+      type: payload.typeString,
+      payload: encoded,
+      createdAt: createdAt,
+    )
+  }
+
+  func toModel() -> WuhuSessionEntry {
+    let decoded: WuhuEntryPayload = Self.decodePayload(type: type, data: payload)
+    return .init(
+      id: id ?? -1,
+      sessionID: sessionID,
+      parentEntryID: parentEntryID,
+      createdAt: createdAt,
+      payload: decoded,
+    )
+  }
+
+  private static func decodePayload(type: String, data: Data) -> WuhuEntryPayload {
+    if let payload = try? WuhuJSON.decoder.decode(WuhuEntryPayload.self, from: data) {
+      return payload
+    }
+    if let json = try? WuhuJSON.decoder.decode(JSONValue.self, from: data) {
+      return .unknown(type: type, payload: json)
+    }
+    return .unknown(type: type, payload: .null)
+  }
+}
+
+extension SQLiteSessionStore {
+  private static let migrator: DatabaseMigrator = {
+    var migrator = DatabaseMigrator()
+
+    migrator.registerMigration("createSessionsAndEntries_v1") { db in
+      try db.create(table: "sessions") { t in
+        t.column("id", .text).primaryKey()
+        t.column("provider", .text).notNull()
+        t.column("model", .text).notNull()
+        t.column("cwd", .text).notNull()
+        t.column("parentSessionID", .text)
+        t.column("createdAt", .datetime).notNull()
+        t.column("updatedAt", .datetime).notNull()
+        t.column("headEntryID", .integer)
+        t.column("tailEntryID", .integer)
+      }
+
+      try db.create(table: "session_entries") { t in
+        t.autoIncrementedPrimaryKey("id")
+        t.column("sessionID", .text).notNull().indexed().references("sessions", onDelete: .cascade)
+        t.column("parentEntryID", .integer).references("session_entries", onDelete: .restrict)
+        t.column("type", .text).notNull().indexed()
+        t.column("payload", .blob).notNull()
+        t.column("createdAt", .datetime).notNull().indexed()
+      }
+
+      // Enforce "no fork within session": parentEntryID can have at most one child across the table.
+      // This also makes linear chain traversal O(n) and tail updates cheap.
+      try db.create(index: "session_entries_unique_parent", on: "session_entries", columns: ["parentEntryID"], unique: true, condition: Column("parentEntryID") != nil)
+
+      // Enforce exactly one header per session: the only entry with parentEntryID IS NULL.
+      try db.create(index: "session_entries_unique_header_per_session", on: "session_entries", columns: ["sessionID"], unique: true, condition: Column("parentEntryID") == nil)
+    }
+
+    return migrator
+  }()
+}

--- a/Sources/WuhuCore/SessionStore.swift
+++ b/Sources/WuhuCore/SessionStore.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public enum WuhuStoreError: Error, Sendable, CustomStringConvertible {
+  case sessionNotFound(String)
+  case sessionCorrupt(String)
+  case noHeaderEntry(String)
+
+  public var description: String {
+    switch self {
+    case let .sessionNotFound(id):
+      "Session not found: \(id)"
+    case let .sessionCorrupt(reason):
+      "Session is corrupt: \(reason)"
+    case let .noHeaderEntry(id):
+      "Session has no header entry: \(id)"
+    }
+  }
+}
+
+public protocol SessionStore: Sendable {
+  func createSession(
+    provider: WuhuProvider,
+    model: String,
+    systemPrompt: String,
+    cwd: String,
+    parentSessionID: String?,
+  ) async throws -> WuhuSession
+
+  func getSession(id: String) async throws -> WuhuSession
+  func listSessions(limit: Int?) async throws -> [WuhuSession]
+
+  @discardableResult
+  func appendEntry(sessionID: String, payload: WuhuEntryPayload) async throws -> WuhuSessionEntry
+  func getEntries(sessionID: String) async throws -> [WuhuSessionEntry]
+}

--- a/Sources/WuhuCore/WuhuCore.docc/WuhuCore.md
+++ b/Sources/WuhuCore/WuhuCore.docc/WuhuCore.md
@@ -1,0 +1,125 @@
+# ``WuhuCore``
+
+WuhuCore provides a persisted, agent-session log for Wuhu’s Swift pivot.
+
+The core design goal is to preserve the **tree-shaped session entry model** used by Pi (JSONL sessions with `id` + `parentId`), but store it in **SQLite (GRDB)** instead of files.
+
+This module intentionally supports only a **single linear chain** within a session (no forks). Forking is modeled as creating a **new session** that references a parent session.
+
+## Overview
+
+Wuhu persists agent sessions into two tables:
+
+- `sessions`: one row per session, including immutable `headEntryID` and mutable `tailEntryID`
+- `session_entries`: one row per entry/event/message across all sessions
+
+Entries form a linked structure via `parentEntryID`. The entry with `parentEntryID = NULL` is the **session header**.
+
+## SQLite Schema
+
+### `sessions`
+
+Logical fields (see `SQLiteSessionStore` migration):
+
+- `id` (TEXT PRIMARY KEY): session id returned to the CLI
+- `provider` (TEXT): `openai`, `anthropic`, `openai-codex`
+- `model` (TEXT): model id
+- `cwd` (TEXT): working directory at session creation
+- `parentSessionID` (TEXT, nullable): reserved for future “fork session” feature
+- `createdAt` / `updatedAt` (DATETIME)
+- `headEntryID` (INTEGER, nullable at the DB level, but treated as required in the model)
+- `tailEntryID` (INTEGER, nullable at the DB level, but treated as required in the model)
+
+**Why `headEntryID` and `tailEntryID` exist**
+
+In a file-based JSONL tree, “find the leaf” is cheap because all candidates live in one file.
+In SQLite, efficient appends require tracking the current leaf (`tailEntryID`) so each new entry can be written with:
+
+1. `parentEntryID = sessions.tailEntryID`
+2. update `sessions.tailEntryID = newEntryID`
+
+### `session_entries`
+
+Logical fields:
+
+- `id` (INTEGER PRIMARY KEY AUTOINCREMENT): entry id, referenced by `sessions.headEntryID` / `tailEntryID`
+- `sessionID` (TEXT, FK → `sessions.id`)
+- `parentEntryID` (INTEGER, nullable, FK → `session_entries.id`)
+- `type` (TEXT): redundant with the JSON payload, used for indexing/debugging
+- `payload` (BLOB): JSON-encoded `WuhuEntryPayload`
+- `createdAt` (DATETIME)
+
+## Invariants (Enforced)
+
+### 1) Exactly one header entry per session
+
+The header is the only entry with `parentEntryID IS NULL`.
+
+SQLite enforces this with a **partial unique index**:
+
+- unique on `sessionID` where `parentEntryID IS NULL`
+
+### 2) No forks within a session
+
+Forking within a session would allow multiple children to share the same parent entry.
+
+Wuhu intentionally disallows this in v1, and SQLite enforces it with:
+
+- unique on `parentEntryID` where `parentEntryID IS NOT NULL`
+
+This means each entry can have **at most one child**, so the session is always a single linear chain from head → tail.
+
+## Entry Payloads
+
+All entry payloads are stored as JSON and decoded into `WuhuEntryPayload`:
+
+- `header`: `WuhuSessionHeader` (includes the session’s `systemPrompt`)
+- `message`: `WuhuPersistedMessage` (user / assistant / tool result / custom message)
+- `tool_execution`: `WuhuToolExecution` (start/end markers)
+- `custom`: extension state (does not participate in LLM context)
+- `unknown`: forward-compatible fallback
+
+### Message payloads
+
+`WuhuPersistedMessage` mirrors the important parts of PiAI message types but stays `Codable`:
+
+- `user`
+- `assistant`
+- `tool_result`
+- `custom_message` (reserved for extensions; participates in context like a user message)
+- `unknown`
+
+This deliberately leaves space for:
+
+- “new entry” types (via `custom` / `unknown`)
+- “message entry” variants (via `custom_message` / `unknown`)
+
+## Concurrency Model
+
+- `SQLiteSessionStore` is an `actor` that wraps a `GRDB.DatabaseQueue`.
+- `WuhuService` is an `actor` that:
+  - loads a transcript from SQLite
+  - runs a `PiAgent.Agent` loop
+  - persists finalized events back to SQLite as the agent runs
+
+All public store APIs are `async` to compose naturally with Swift concurrency.
+
+## CLI Integration
+
+The `wuhu` executable is a thin wrapper around `WuhuService`:
+
+- `wuhu create-session --provider openai` → prints session id
+- `wuhu prompt --session-id <id> <prompt...>` → appends and streams response
+- `wuhu get-session --session-id <id>` → prints metadata + transcript
+- `wuhu list-sessions` → lists sessions
+
+## Future: Forking Sessions (Not Implemented)
+
+Forking is expected to be implemented by:
+
+1. Creating a **new** `sessions` row with `parentSessionID` pointing to the source session
+2. Creating a new header entry
+3. Copying or referencing the desired prefix of entries into the new session (implementation choice)
+
+This keeps per-session chains linear while still supporting “branching” at the session level.
+

--- a/Sources/WuhuCore/WuhuJSON.swift
+++ b/Sources/WuhuCore/WuhuJSON.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum WuhuJSON {
+  static let encoder: JSONEncoder = {
+    let e = JSONEncoder()
+    e.outputFormatting = [.sortedKeys]
+    e.dateEncodingStrategy = .secondsSince1970
+    return e
+  }()
+
+  static let decoder: JSONDecoder = {
+    let d = JSONDecoder()
+    d.dateDecodingStrategy = .secondsSince1970
+    return d
+  }()
+}

--- a/Sources/WuhuCore/WuhuPersistedMessage.swift
+++ b/Sources/WuhuCore/WuhuPersistedMessage.swift
@@ -1,0 +1,303 @@
+import Foundation
+import PiAI
+
+public enum WuhuContentBlock: Sendable, Hashable, Codable {
+  case text(text: String, signature: String?)
+  case toolCall(id: String, name: String, arguments: JSONValue)
+
+  enum CodingKeys: String, CodingKey {
+    case type
+    case text
+    case signature
+    case id
+    case name
+    case arguments
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    let type = try c.decode(String.self, forKey: .type)
+    switch type {
+    case "text":
+      self = try .text(text: c.decode(String.self, forKey: .text), signature: c.decodeIfPresent(String.self, forKey: .signature))
+    case "tool_call":
+      self = try .toolCall(
+        id: c.decode(String.self, forKey: .id),
+        name: c.decode(String.self, forKey: .name),
+        arguments: c.decode(JSONValue.self, forKey: .arguments),
+      )
+    default:
+      throw DecodingError.dataCorruptedError(forKey: .type, in: c, debugDescription: "Unknown content block type: \(type)")
+    }
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var c = encoder.container(keyedBy: CodingKeys.self)
+    switch self {
+    case let .text(text, signature):
+      try c.encode("text", forKey: .type)
+      try c.encode(text, forKey: .text)
+      try c.encodeIfPresent(signature, forKey: .signature)
+    case let .toolCall(id, name, arguments):
+      try c.encode("tool_call", forKey: .type)
+      try c.encode(id, forKey: .id)
+      try c.encode(name, forKey: .name)
+      try c.encode(arguments, forKey: .arguments)
+    }
+  }
+
+  public static func fromPi(_ b: ContentBlock) -> WuhuContentBlock {
+    switch b {
+    case let .text(t):
+      .text(text: t.text, signature: t.signature)
+    case let .toolCall(c):
+      .toolCall(id: c.id, name: c.name, arguments: c.arguments)
+    }
+  }
+
+  public func toPi() -> ContentBlock {
+    switch self {
+    case let .text(text, signature):
+      .text(.init(text: text, signature: signature))
+    case let .toolCall(id, name, arguments):
+      .toolCall(.init(id: id, name: name, arguments: arguments))
+    }
+  }
+}
+
+public struct WuhuUsage: Sendable, Hashable, Codable {
+  public var inputTokens: Int
+  public var outputTokens: Int
+  public var totalTokens: Int
+
+  public init(inputTokens: Int, outputTokens: Int, totalTokens: Int) {
+    self.inputTokens = inputTokens
+    self.outputTokens = outputTokens
+    self.totalTokens = totalTokens
+  }
+
+  public static func fromPi(_ u: Usage) -> WuhuUsage {
+    .init(inputTokens: u.inputTokens, outputTokens: u.outputTokens, totalTokens: u.totalTokens)
+  }
+
+  public func toPi() -> Usage {
+    .init(inputTokens: inputTokens, outputTokens: outputTokens, totalTokens: totalTokens)
+  }
+}
+
+public struct WuhuUserMessage: Sendable, Hashable, Codable {
+  public var content: [WuhuContentBlock]
+  public var timestamp: Date
+
+  public init(content: [WuhuContentBlock], timestamp: Date) {
+    self.content = content
+    self.timestamp = timestamp
+  }
+
+  public static func fromPi(_ m: UserMessage) -> WuhuUserMessage {
+    .init(content: m.content.map(WuhuContentBlock.fromPi), timestamp: m.timestamp)
+  }
+
+  public func toPi() -> UserMessage {
+    .init(content: content.map { $0.toPi() }, timestamp: timestamp)
+  }
+}
+
+public struct WuhuAssistantMessage: Sendable, Hashable, Codable {
+  public var provider: WuhuProvider
+  public var model: String
+  public var content: [WuhuContentBlock]
+  public var usage: WuhuUsage?
+  public var stopReason: String
+  public var errorMessage: String?
+  public var timestamp: Date
+
+  public init(
+    provider: WuhuProvider,
+    model: String,
+    content: [WuhuContentBlock],
+    usage: WuhuUsage?,
+    stopReason: String,
+    errorMessage: String?,
+    timestamp: Date,
+  ) {
+    self.provider = provider
+    self.model = model
+    self.content = content
+    self.usage = usage
+    self.stopReason = stopReason
+    self.errorMessage = errorMessage
+    self.timestamp = timestamp
+  }
+
+  public static func fromPi(_ m: AssistantMessage) -> WuhuAssistantMessage {
+    .init(
+      provider: .init(rawValue: m.provider.rawValue) ?? .openai,
+      model: m.model,
+      content: m.content.map(WuhuContentBlock.fromPi),
+      usage: m.usage.map(WuhuUsage.fromPi),
+      stopReason: m.stopReason.rawValue,
+      errorMessage: m.errorMessage,
+      timestamp: m.timestamp,
+    )
+  }
+
+  public func toPi() -> AssistantMessage {
+    .init(
+      provider: provider.piProvider,
+      model: model,
+      content: content.map { $0.toPi() },
+      usage: usage?.toPi(),
+      stopReason: StopReason(rawValue: stopReason) ?? .stop,
+      errorMessage: errorMessage,
+      timestamp: timestamp,
+    )
+  }
+}
+
+public struct WuhuToolResultMessage: Sendable, Hashable, Codable {
+  public var toolCallId: String
+  public var toolName: String
+  public var content: [WuhuContentBlock]
+  public var details: JSONValue
+  public var isError: Bool
+  public var timestamp: Date
+
+  public init(
+    toolCallId: String,
+    toolName: String,
+    content: [WuhuContentBlock],
+    details: JSONValue,
+    isError: Bool,
+    timestamp: Date,
+  ) {
+    self.toolCallId = toolCallId
+    self.toolName = toolName
+    self.content = content
+    self.details = details
+    self.isError = isError
+    self.timestamp = timestamp
+  }
+
+  public static func fromPi(_ m: ToolResultMessage) -> WuhuToolResultMessage {
+    .init(
+      toolCallId: m.toolCallId,
+      toolName: m.toolName,
+      content: m.content.map(WuhuContentBlock.fromPi),
+      details: m.details,
+      isError: m.isError,
+      timestamp: m.timestamp,
+    )
+  }
+
+  public func toPi() -> ToolResultMessage {
+    .init(
+      toolCallId: toolCallId,
+      toolName: toolName,
+      content: content.map { $0.toPi() },
+      details: details,
+      isError: isError,
+      timestamp: timestamp,
+    )
+  }
+}
+
+public struct WuhuCustomMessage: Sendable, Hashable, Codable {
+  public var customType: String
+  public var content: [WuhuContentBlock]
+  public var details: JSONValue?
+  public var display: Bool
+  public var timestamp: Date
+
+  public init(
+    customType: String,
+    content: [WuhuContentBlock],
+    details: JSONValue?,
+    display: Bool,
+    timestamp: Date,
+  ) {
+    self.customType = customType
+    self.content = content
+    self.details = details
+    self.display = display
+    self.timestamp = timestamp
+  }
+}
+
+public enum WuhuPersistedMessage: Sendable, Hashable, Codable {
+  case user(WuhuUserMessage)
+  case assistant(WuhuAssistantMessage)
+  case toolResult(WuhuToolResultMessage)
+  case customMessage(WuhuCustomMessage)
+  case unknown(role: String, payload: JSONValue)
+
+  enum CodingKeys: String, CodingKey {
+    case role
+    case message
+    case payload
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    let role = try c.decode(String.self, forKey: .role)
+    switch role {
+    case "user":
+      self = try .user(c.decode(WuhuUserMessage.self, forKey: .message))
+    case "assistant":
+      self = try .assistant(c.decode(WuhuAssistantMessage.self, forKey: .message))
+    case "tool_result":
+      self = try .toolResult(c.decode(WuhuToolResultMessage.self, forKey: .message))
+    case "custom_message":
+      self = try .customMessage(c.decode(WuhuCustomMessage.self, forKey: .message))
+    default:
+      self = try .unknown(role: role, payload: (c.decodeIfPresent(JSONValue.self, forKey: .payload)) ?? .null)
+    }
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var c = encoder.container(keyedBy: CodingKeys.self)
+    switch self {
+    case let .user(m):
+      try c.encode("user", forKey: .role)
+      try c.encode(m, forKey: .message)
+    case let .assistant(m):
+      try c.encode("assistant", forKey: .role)
+      try c.encode(m, forKey: .message)
+    case let .toolResult(m):
+      try c.encode("tool_result", forKey: .role)
+      try c.encode(m, forKey: .message)
+    case let .customMessage(m):
+      try c.encode("custom_message", forKey: .role)
+      try c.encode(m, forKey: .message)
+    case let .unknown(role, payload):
+      try c.encode(role, forKey: .role)
+      try c.encode(payload, forKey: .payload)
+    }
+  }
+
+  public static func fromPi(_ m: Message) -> WuhuPersistedMessage {
+    switch m {
+    case let .user(u):
+      .user(.fromPi(u))
+    case let .assistant(a):
+      .assistant(.fromPi(a))
+    case let .toolResult(t):
+      .toolResult(.fromPi(t))
+    }
+  }
+
+  public func toPiMessage() -> Message? {
+    switch self {
+    case let .user(u):
+      .user(u.toPi())
+    case let .assistant(a):
+      .assistant(a.toPi())
+    case let .toolResult(t):
+      .toolResult(t.toPi())
+    case let .customMessage(c):
+      .user(.init(content: c.content.map { $0.toPi() }, timestamp: c.timestamp))
+    case .unknown:
+      nil
+    }
+  }
+}

--- a/Sources/WuhuCore/WuhuProvider.swift
+++ b/Sources/WuhuCore/WuhuProvider.swift
@@ -1,0 +1,18 @@
+import PiAI
+
+public enum WuhuProvider: String, Sendable, Codable, CaseIterable, Hashable {
+  case openai
+  case openaiCodex = "openai-codex"
+  case anthropic
+
+  public var piProvider: Provider {
+    switch self {
+    case .openai:
+      .openai
+    case .openaiCodex:
+      .openaiCodex
+    case .anthropic:
+      .anthropic
+    }
+  }
+}

--- a/Sources/WuhuCore/WuhuService.swift
+++ b/Sources/WuhuCore/WuhuService.swift
@@ -1,0 +1,176 @@
+import Foundation
+import PiAgent
+import PiAI
+
+public enum WuhuPromptStreamEvent: Sendable, Hashable {
+  case toolExecutionStart(toolCallId: String, toolName: String, args: JSONValue)
+  case toolExecutionEnd(toolCallId: String, toolName: String, result: AgentToolResult, isError: Bool)
+  case assistantTextDelta(String)
+  case done
+}
+
+public actor WuhuService {
+  private let store: any SessionStore
+
+  public init(store: any SessionStore) {
+    self.store = store
+  }
+
+  public func createSession(
+    provider: WuhuProvider,
+    model: String,
+    systemPrompt: String,
+    cwd: String = FileManager.default.currentDirectoryPath,
+    parentSessionID: String? = nil,
+  ) async throws -> WuhuSession {
+    try await store.createSession(
+      provider: provider,
+      model: model,
+      systemPrompt: systemPrompt,
+      cwd: cwd,
+      parentSessionID: parentSessionID,
+    )
+  }
+
+  public func listSessions(limit: Int? = nil) async throws -> [WuhuSession] {
+    try await store.listSessions(limit: limit)
+  }
+
+  public func getSession(id: String) async throws -> WuhuSession {
+    try await store.getSession(id: id)
+  }
+
+  public func getTranscript(sessionID: String) async throws -> [WuhuSessionEntry] {
+    try await store.getEntries(sessionID: sessionID)
+  }
+
+  public func promptStream(
+    sessionID: String,
+    input: String,
+    maxTurns: Int = 12,
+    tools: [AnyAgentTool] = [WuhuTools.simulatedWeatherTool()],
+    streamFn: @escaping StreamFn = PiAI.streamSimple,
+  ) async throws -> AsyncThrowingStream<WuhuPromptStreamEvent, any Error> {
+    let session = try await store.getSession(id: sessionID)
+    let transcript = try await store.getEntries(sessionID: sessionID)
+
+    let header = try Self.extractHeader(from: transcript, sessionID: sessionID)
+    let messages = Self.extractContextMessages(from: transcript)
+
+    let model = Model(id: session.model, provider: session.provider.piProvider)
+
+    let agent = PiAgent.Agent(opts: .init(
+      initialState: .init(
+        systemPrompt: header.systemPrompt,
+        model: model,
+        tools: tools,
+        messages: messages,
+      ),
+      streamFn: streamFn,
+      maxTurns: maxTurns,
+    ))
+
+    return AsyncThrowingStream(WuhuPromptStreamEvent.self, bufferingPolicy: .bufferingNewest(1024)) { continuation in
+      let task = Task {
+        do {
+          let consumeTask = Task {
+            for try await event in agent.events {
+              try await self.handleAgentEvent(event, sessionID: sessionID, continuation: continuation)
+              if case .agentEnd = event { break }
+            }
+          }
+          defer { consumeTask.cancel() }
+          try await agent.prompt(input)
+          _ = try await consumeTask.value
+
+          continuation.yield(.done)
+          continuation.finish()
+        } catch {
+          continuation.finish(throwing: error)
+        }
+      }
+
+      continuation.onTermination = { _ in
+        task.cancel()
+        Task { await agent.abort() }
+      }
+    }
+  }
+
+  private func handleAgentEvent(
+    _ event: AgentEvent,
+    sessionID: String,
+    continuation: AsyncThrowingStream<WuhuPromptStreamEvent, any Error>.Continuation,
+  ) async throws {
+    switch event {
+    case let .toolExecutionStart(toolCallId, toolName, args):
+      continuation.yield(.toolExecutionStart(toolCallId: toolCallId, toolName: toolName, args: args))
+      try await store.appendEntry(sessionID: sessionID, payload: .toolExecution(.init(
+        phase: .start,
+        toolCallId: toolCallId,
+        toolName: toolName,
+        arguments: args,
+      )))
+
+    case let .toolExecutionEnd(toolCallId, toolName, result, isError):
+      continuation.yield(.toolExecutionEnd(toolCallId: toolCallId, toolName: toolName, result: result, isError: isError))
+      try await store.appendEntry(sessionID: sessionID, payload: .toolExecution(.init(
+        phase: .end,
+        toolCallId: toolCallId,
+        toolName: toolName,
+        arguments: .null,
+        result: .object([
+          "content": .array(result.content.map(Self.contentBlockToJSON)),
+          "details": result.details,
+        ]),
+        isError: isError,
+      )))
+
+    case let .messageUpdate(message, assistantEvent):
+      if case .assistant = message, case let .textDelta(delta, _) = assistantEvent {
+        continuation.yield(.assistantTextDelta(delta))
+      }
+
+    case let .messageEnd(message):
+      try await store.appendEntry(sessionID: sessionID, payload: .message(.fromPi(message)))
+
+    default:
+      break
+    }
+  }
+
+  private static func extractHeader(from transcript: [WuhuSessionEntry], sessionID: String) throws -> WuhuSessionHeader {
+    guard let headerEntry = transcript.first(where: { $0.parentEntryID == nil }) else {
+      throw WuhuStoreError.noHeaderEntry(sessionID)
+    }
+    guard case let .header(header) = headerEntry.payload else {
+      throw WuhuStoreError.sessionCorrupt("Header entry \(headerEntry.id) payload is not header")
+    }
+    return header
+  }
+
+  private static func extractContextMessages(from transcript: [WuhuSessionEntry]) -> [Message] {
+    transcript.compactMap { entry in
+      guard case let .message(m) = entry.payload else { return nil }
+      return m.toPiMessage()
+    }
+  }
+
+  private static func contentBlockToJSON(_ block: ContentBlock) -> JSONValue {
+    switch block {
+    case let .text(t):
+      var obj: [String: JSONValue] = ["type": .string("text"), "text": .string(t.text)]
+      if let signature = t.signature {
+        obj["signature"] = .string(signature)
+      }
+      return .object(obj)
+    case let .toolCall(c):
+      return .object([
+        "type": .string("tool_call"),
+        "id": .string(c.id),
+        "name": .string(c.name),
+        "arguments": c.arguments,
+      ])
+    }
+  }
+}

--- a/Sources/WuhuCore/WuhuSession.swift
+++ b/Sources/WuhuCore/WuhuSession.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public struct WuhuSession: Sendable, Hashable, Codable, Identifiable {
+  public var id: String
+  public var provider: WuhuProvider
+  public var model: String
+  public var cwd: String
+  public var parentSessionID: String?
+  public var createdAt: Date
+  public var updatedAt: Date
+  public var headEntryID: Int64
+  public var tailEntryID: Int64
+
+  public init(
+    id: String,
+    provider: WuhuProvider,
+    model: String,
+    cwd: String,
+    parentSessionID: String?,
+    createdAt: Date,
+    updatedAt: Date,
+    headEntryID: Int64,
+    tailEntryID: Int64,
+  ) {
+    self.id = id
+    self.provider = provider
+    self.model = model
+    self.cwd = cwd
+    self.parentSessionID = parentSessionID
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
+    self.headEntryID = headEntryID
+    self.tailEntryID = tailEntryID
+  }
+}

--- a/Sources/WuhuCore/WuhuSessionEntry.swift
+++ b/Sources/WuhuCore/WuhuSessionEntry.swift
@@ -1,0 +1,135 @@
+import Foundation
+import PiAI
+
+public struct WuhuSessionHeader: Sendable, Hashable, Codable {
+  public var version: Int
+  public var systemPrompt: String
+  public var metadata: JSONValue
+
+  public init(version: Int = 1, systemPrompt: String, metadata: JSONValue = .object([:])) {
+    self.version = version
+    self.systemPrompt = systemPrompt
+    self.metadata = metadata
+  }
+}
+
+public struct WuhuToolExecution: Sendable, Hashable, Codable {
+  public enum Phase: String, Sendable, Hashable, Codable {
+    case start
+    case end
+  }
+
+  public var phase: Phase
+  public var toolCallId: String
+  public var toolName: String
+  public var arguments: JSONValue
+  public var result: JSONValue?
+  public var isError: Bool?
+
+  public init(
+    phase: Phase,
+    toolCallId: String,
+    toolName: String,
+    arguments: JSONValue,
+    result: JSONValue? = nil,
+    isError: Bool? = nil,
+  ) {
+    self.phase = phase
+    self.toolCallId = toolCallId
+    self.toolName = toolName
+    self.arguments = arguments
+    self.result = result
+    self.isError = isError
+  }
+}
+
+public enum WuhuEntryPayload: Sendable, Hashable, Codable {
+  case header(WuhuSessionHeader)
+  case message(WuhuPersistedMessage)
+  case toolExecution(WuhuToolExecution)
+  case custom(customType: String, data: JSONValue?)
+  case unknown(type: String, payload: JSONValue)
+
+  enum CodingKeys: String, CodingKey {
+    case type
+    case payload
+    case customType
+    case data
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    let type = try c.decode(String.self, forKey: .type)
+    switch type {
+    case "header":
+      self = try .header(c.decode(WuhuSessionHeader.self, forKey: .payload))
+    case "message":
+      self = try .message(c.decode(WuhuPersistedMessage.self, forKey: .payload))
+    case "tool_execution":
+      self = try .toolExecution(c.decode(WuhuToolExecution.self, forKey: .payload))
+    case "custom":
+      self = try .custom(customType: c.decode(String.self, forKey: .customType), data: c.decodeIfPresent(JSONValue.self, forKey: .data))
+    default:
+      self = try .unknown(type: type, payload: (c.decodeIfPresent(JSONValue.self, forKey: .payload)) ?? .null)
+    }
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var c = encoder.container(keyedBy: CodingKeys.self)
+    switch self {
+    case let .header(h):
+      try c.encode("header", forKey: .type)
+      try c.encode(h, forKey: .payload)
+    case let .message(m):
+      try c.encode("message", forKey: .type)
+      try c.encode(m, forKey: .payload)
+    case let .toolExecution(t):
+      try c.encode("tool_execution", forKey: .type)
+      try c.encode(t, forKey: .payload)
+    case let .custom(customType, data):
+      try c.encode("custom", forKey: .type)
+      try c.encode(customType, forKey: .customType)
+      try c.encodeIfPresent(data, forKey: .data)
+    case let .unknown(type, payload):
+      try c.encode(type, forKey: .type)
+      try c.encode(payload, forKey: .payload)
+    }
+  }
+
+  public var typeString: String {
+    switch self {
+    case .header:
+      "header"
+    case .message:
+      "message"
+    case .toolExecution:
+      "tool_execution"
+    case .custom:
+      "custom"
+    case let .unknown(type, _):
+      type
+    }
+  }
+}
+
+public struct WuhuSessionEntry: Sendable, Hashable, Identifiable {
+  public var id: Int64
+  public var sessionID: String
+  public var parentEntryID: Int64?
+  public var createdAt: Date
+  public var payload: WuhuEntryPayload
+
+  public init(
+    id: Int64,
+    sessionID: String,
+    parentEntryID: Int64?,
+    createdAt: Date,
+    payload: WuhuEntryPayload,
+  ) {
+    self.id = id
+    self.sessionID = sessionID
+    self.parentEntryID = parentEntryID
+    self.createdAt = createdAt
+    self.payload = payload
+  }
+}

--- a/Sources/WuhuCore/WuhuTools.swift
+++ b/Sources/WuhuCore/WuhuTools.swift
@@ -1,0 +1,78 @@
+import Foundation
+import PiAgent
+import PiAI
+
+public enum WuhuTools {
+  public static func simulatedWeatherTool() -> AnyAgentTool {
+    struct Params: Decodable, Sendable {
+      var city: String
+    }
+
+    let schema: JSONValue = .object([
+      "type": .string("object"),
+      "properties": .object([
+        "city": .object([
+          "type": .string("string"),
+          "description": .string("City name, e.g. San Francisco"),
+        ]),
+      ]),
+      "required": .array([.string("city")]),
+      "additionalProperties": .bool(false),
+    ])
+
+    return AnyAgentTool(
+      name: "weather",
+      label: "Weather",
+      description: "Get simulated weather data for a city (demo tool; returns fake data).",
+      parametersSchema: schema,
+      execute: { (_: String, params: Params) in
+        let report = simulatedWeather(for: params.city)
+        let text = "\(report.city): \(report.temperatureC)°C, \(report.condition) (simulated)"
+        return AgentToolResult(
+          content: [.text(text)],
+          details: .object([
+            "city": .string(report.city),
+            "temperatureC": .number(Double(report.temperatureC)),
+            "condition": .string(report.condition),
+            "source": .string("simulated"),
+          ]),
+        )
+      },
+    )
+  }
+}
+
+private struct WeatherReport: Sendable {
+  var city: String
+  var temperatureC: Int
+  var condition: String
+}
+
+private func simulatedWeather(for cityRaw: String) -> WeatherReport {
+  let city = cityRaw.trimmingCharacters(in: .whitespacesAndNewlines)
+  let normalized = city.lowercased()
+
+  let fixed: [String: WeatherReport] = [
+    "san francisco": .init(city: "San Francisco", temperatureC: 18, condition: "foggy"),
+    "san diego": .init(city: "San Diego", temperatureC: 24, condition: "sunny"),
+    "tokyo": .init(city: "Tokyo", temperatureC: 29, condition: "humid"),
+    "new york": .init(city: "New York", temperatureC: 6, condition: "windy"),
+  ]
+  if let report = fixed[normalized] { return report }
+
+  let hash = stableHash(normalized)
+  let temp = 5 + Int(hash % 26) // 5..30
+  let conditions = ["sunny", "cloudy", "rainy", "windy", "foggy"]
+  let condition = conditions[Int((hash / 31) % UInt64(conditions.count))]
+  return .init(city: city.isEmpty ? "Unknown" : city, temperatureC: temp, condition: condition)
+}
+
+private func stableHash(_ s: String) -> UInt64 {
+  // FNV-1a 64-bit
+  var hash: UInt64 = 14_695_981_039_346_656_037
+  for b in s.utf8 {
+    hash ^= UInt64(b)
+    hash &*= 1_099_511_628_211
+  }
+  return hash
+}

--- a/Tests/WuhuCoreTests/WuhuCoreTests.swift
+++ b/Tests/WuhuCoreTests/WuhuCoreTests.swift
@@ -1,0 +1,114 @@
+import Testing
+import WuhuCore
+
+struct WuhuCoreTests {
+  @Test func createSessionCreatesHeaderAndHeadTail() async throws {
+    let store = try SQLiteSessionStore(path: ":memory:")
+    let service = WuhuService(store: store)
+
+    let session = try await service.createSession(
+      provider: .openai,
+      model: "mock",
+      systemPrompt: "You are helpful.",
+      cwd: "/tmp",
+    )
+
+    #expect(session.provider == .openai)
+    #expect(session.model == "mock")
+    #expect(session.headEntryID == session.tailEntryID)
+
+    let entries = try await service.getTranscript(sessionID: session.id)
+    #expect(entries.count == 1)
+    #expect(entries[0].id == session.headEntryID)
+    #expect(entries[0].parentEntryID == nil)
+
+    guard case let .header(header) = entries[0].payload else {
+      #expect(Bool(false))
+      return
+    }
+    #expect(header.systemPrompt == "You are helpful.")
+  }
+
+  @Test func promptStreamPersistsLinearChain() async throws {
+    let store = try SQLiteSessionStore(path: ":memory:")
+    let service = WuhuService(store: store)
+
+    let session = try await service.createSession(
+      provider: .openai,
+      model: "mock",
+      systemPrompt: "You are a terminal agent.",
+      cwd: "/tmp",
+    )
+
+    actor StreamState {
+      var callCount = 0
+
+      func stream(model: Model, ctx: Context, _: RequestOptions) -> AsyncThrowingStream<AssistantMessageEvent, any Error> {
+        callCount += 1
+        let n = callCount
+
+        return AsyncThrowingStream<AssistantMessageEvent, any Error> { continuation in
+          Task {
+            if n == 1 {
+              let toolCall = ToolCall(
+                id: "tool-1",
+                name: "weather",
+                arguments: .object(["city": .string("Tokyo")]),
+              )
+              let assistant = AssistantMessage(
+                provider: model.provider,
+                model: model.id,
+                content: [.toolCall(toolCall)],
+                stopReason: .toolUse,
+              )
+              continuation.yield(.done(message: assistant))
+              continuation.finish()
+              return
+            }
+
+            let sawToolResult = ctx.messages.contains(where: { msg in
+              if case .toolResult = msg { return true }
+              return false
+            })
+
+            let text = sawToolResult ? "Tokyo is 29°C (simulated)." : "Missing tool result."
+            let assistant = AssistantMessage(
+              provider: model.provider,
+              model: model.id,
+              content: [.text(text)],
+              stopReason: .stop,
+            )
+            continuation.yield(.done(message: assistant))
+            continuation.finish()
+          }
+        }
+      }
+    }
+
+    let state = StreamState()
+
+    let stream = try await service.promptStream(
+      sessionID: session.id,
+      input: "What's the weather in Tokyo?",
+      maxTurns: 5,
+      tools: [WuhuTools.simulatedWeatherTool()],
+      streamFn: { model, ctx, opts in
+        await state.stream(model: model, ctx: ctx, opts)
+      },
+    )
+
+    for try await _ in stream {}
+
+    let entries = try await service.getTranscript(sessionID: session.id)
+    #expect(entries.count == 7)
+
+    // 1 header + 6 appended entries, all in a single parent-linked chain.
+    #expect(entries[0].parentEntryID == nil)
+    for i in 1 ..< entries.count {
+      #expect(entries[i].parentEntryID == entries[i - 1].id)
+    }
+
+    let tail = try await service.getSession(id: session.id).tailEntryID
+    #expect(entries.last?.id == tail)
+  }
+}


### PR DESCRIPTION
Implements persisted agent sessions backed by SQLite (GRDB), replacing the previous throwaway CLI demo.

Key points:
- Adds `WuhuCore` target with `sessions` + `session_entries` schema (head/tail tracked on `sessions`, parent pointers on entries, single-chain enforced via unique indexes).
- Adds `SQLiteSessionStore` + `WuhuService` (PiAgent loop + streaming + persistence).
- Rewrites `wuhu` CLI to:
  - `wuhu create-session --provider openai`
  - `wuhu prompt --session-id <id> <prompt...>`
  - `wuhu get-session --session-id <id>`
  - `wuhu list-sessions`
- Adds DocC design docs: `Sources/WuhuCore/WuhuCore.docc/WuhuCore.md`.
- Adds tests for store + persisted prompt flow (`Tests/WuhuCoreTests`).

Validation:
- `swift test`
- `swift package --allow-writing-to-package-directory swiftformat --lint .`
