### PR TITLE
Fix OpenAI reasoning replay across tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ swift run wuhu list-sessions
 ```
 
 The CLI reads `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` from the environment and will also load a local `.env` if present.
+
+For OpenAI Responses debugging (especially with tool calls + reasoning items), you can enable request storage with `PIAI_OPENAI_STORE=1`.

--- a/Sources/PiAI/Internal/ProviderHelpers.swift
+++ b/Sources/PiAI/Internal/ProviderHelpers.swift
@@ -6,6 +6,21 @@ func resolveAPIKey(_ explicit: String?, env: String, provider: Provider) throws 
   throw PiAIError.missingAPIKey(provider: provider)
 }
 
+func envFlag(_ key: String, default defaultValue: Bool = false) -> Bool {
+  guard let raw = ProcessInfo.processInfo.environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines),
+        !raw.isEmpty
+  else { return defaultValue }
+
+  switch raw.lowercased() {
+  case "1", "true", "yes", "y", "on":
+    return true
+  case "0", "false", "no", "n", "off":
+    return false
+  default:
+    return defaultValue
+  }
+}
+
 func parseJSON(_ text: String) throws -> [String: Any]? {
   let data = Data(text.utf8)
   let obj = try JSONSerialization.jsonObject(with: data)

--- a/Sources/PiAI/Providers/AnthropicMessagesProvider.swift
+++ b/Sources/PiAI/Providers/AnthropicMessagesProvider.swift
@@ -71,6 +71,8 @@ public struct AnthropicMessagesProvider: Sendable {
               "type": "text",
               "text": part.text,
             ])
+          case .thinking:
+            continue
           case let .toolCall(call):
             blocks.append([
               "type": "tool_use",

--- a/Sources/PiAI/Providers/OpenAICodexResponsesProvider.swift
+++ b/Sources/PiAI/Providers/OpenAICodexResponsesProvider.swift
@@ -41,6 +41,8 @@ public struct OpenAICodexResponsesProvider: Sendable {
   }
 
   private func buildBody(model: Model, context: Context, options: RequestOptions) -> [String: Any] {
+    let store = envFlag("PIAI_OPENAI_STORE", default: false)
+
     var input: [[String: Any]] = []
     for message in context.messages {
       switch message {
@@ -68,7 +70,7 @@ public struct OpenAICodexResponsesProvider: Sendable {
     var body: [String: Any] = [
       "model": model.id,
       "stream": true,
-      "store": false,
+      "store": store,
       "instructions": context.systemPrompt as Any,
       "input": input,
       "text": ["verbosity": "medium"],

--- a/Sources/PiAI/Types.swift
+++ b/Sources/PiAI/Types.swift
@@ -70,6 +70,7 @@ public struct ToolCall: Sendable, Hashable {
 
 public enum ContentBlock: Sendable, Hashable {
   case text(TextContent)
+  case thinking(ThinkingContent)
   case toolCall(ToolCall)
 }
 
@@ -173,6 +174,20 @@ public struct TextContent: Sendable, Hashable {
   }
 }
 
+public struct ThinkingContent: Sendable, Hashable {
+  /// A user-visible "thinking summary" if available (e.g. OpenAI reasoning summary).
+  public var thinking: String
+  /// Provider-specific opaque signature that can be replayed in follow-up requests.
+  ///
+  /// For OpenAI Responses API this is a JSON-encoded `reasoning` output item.
+  public var signature: String?
+
+  public init(thinking: String, signature: String? = nil) {
+    self.thinking = thinking
+    self.signature = signature
+  }
+}
+
 public struct AssistantMessage: Sendable, Hashable {
   public var provider: Provider
   public var model: String
@@ -235,6 +250,10 @@ public enum AssistantMessageEvent: Sendable, Hashable {
 public extension ContentBlock {
   static func text(_ text: String, signature: String? = nil) -> ContentBlock {
     .text(.init(text: text, signature: signature))
+  }
+
+  static func thinking(_ thinking: String, signature: String? = nil) -> ContentBlock {
+    .thinking(.init(thinking: thinking, signature: signature))
   }
 }
 

--- a/Sources/WuhuCore/WuhuPersistedMessage.swift
+++ b/Sources/WuhuCore/WuhuPersistedMessage.swift
@@ -3,11 +3,13 @@ import PiAI
 
 public enum WuhuContentBlock: Sendable, Hashable, Codable {
   case text(text: String, signature: String?)
+  case thinking(thinking: String, signature: String?)
   case toolCall(id: String, name: String, arguments: JSONValue)
 
   enum CodingKeys: String, CodingKey {
     case type
     case text
+    case thinking
     case signature
     case id
     case name
@@ -20,6 +22,11 @@ public enum WuhuContentBlock: Sendable, Hashable, Codable {
     switch type {
     case "text":
       self = try .text(text: c.decode(String.self, forKey: .text), signature: c.decodeIfPresent(String.self, forKey: .signature))
+    case "thinking":
+      self = try .thinking(
+        thinking: c.decode(String.self, forKey: .thinking),
+        signature: c.decodeIfPresent(String.self, forKey: .signature),
+      )
     case "tool_call":
       self = try .toolCall(
         id: c.decode(String.self, forKey: .id),
@@ -38,6 +45,10 @@ public enum WuhuContentBlock: Sendable, Hashable, Codable {
       try c.encode("text", forKey: .type)
       try c.encode(text, forKey: .text)
       try c.encodeIfPresent(signature, forKey: .signature)
+    case let .thinking(thinking, signature):
+      try c.encode("thinking", forKey: .type)
+      try c.encode(thinking, forKey: .thinking)
+      try c.encodeIfPresent(signature, forKey: .signature)
     case let .toolCall(id, name, arguments):
       try c.encode("tool_call", forKey: .type)
       try c.encode(id, forKey: .id)
@@ -50,6 +61,8 @@ public enum WuhuContentBlock: Sendable, Hashable, Codable {
     switch b {
     case let .text(t):
       .text(text: t.text, signature: t.signature)
+    case let .thinking(t):
+      .thinking(thinking: t.thinking, signature: t.signature)
     case let .toolCall(c):
       .toolCall(id: c.id, name: c.name, arguments: c.arguments)
     }
@@ -59,6 +72,8 @@ public enum WuhuContentBlock: Sendable, Hashable, Codable {
     switch self {
     case let .text(text, signature):
       .text(.init(text: text, signature: signature))
+    case let .thinking(thinking, signature):
+      .thinking(.init(thinking: thinking, signature: signature))
     case let .toolCall(id, name, arguments):
       .toolCall(.init(id: id, name: name, arguments: arguments))
     }

--- a/Sources/WuhuCore/WuhuService.swift
+++ b/Sources/WuhuCore/WuhuService.swift
@@ -164,6 +164,12 @@ public actor WuhuService {
         obj["signature"] = .string(signature)
       }
       return .object(obj)
+    case let .thinking(t):
+      var obj: [String: JSONValue] = ["type": .string("thinking"), "thinking": .string(t.thinking)]
+      if let signature = t.signature {
+        obj["signature"] = .string(signature)
+      }
+      return .object(obj)
     case let .toolCall(c):
       return .object([
         "type": .string("tool_call"),

--- a/Sources/wuhu/main.swift
+++ b/Sources/wuhu/main.swift
@@ -272,6 +272,8 @@ private func renderBlocks(_ blocks: [WuhuContentBlock]) -> String {
     switch block {
     case let .text(text, _):
       text
+    case let .thinking(thinking, _):
+      thinking.isEmpty ? nil : "[thinking \(thinking)]"
     case let .toolCall(_, name, arguments):
       "[tool_call \(name) args=\(formatJSON(arguments))]"
     }

--- a/Tests/PiAITests/OpenAIResponsesProviderTests.swift
+++ b/Tests/PiAITests/OpenAIResponsesProviderTests.swift
@@ -39,4 +39,137 @@ struct OpenAIResponsesProviderTests {
     #expect(message.content == [.text(.init(text: "Hello"))])
     #expect(message.usage == Usage(inputTokens: 1, outputTokens: 2, totalTokens: 3))
   }
+
+  @Test func capturesReasoningItemAndReplaysItInFollowUpRequests() async throws {
+    let apiKey = "sk-test"
+
+    let reasoningItem: [String: Any] = [
+      "type": "reasoning",
+      "id": "rs_1",
+      "summary": [["type": "summary_text", "text": "plan"]],
+      "encrypted_content": "enc_abc",
+    ]
+    let reasoningSignature = try jsonString(reasoningItem)
+
+    let capture = BodyCapture()
+    let http = MockHTTPClient(sseHandler: { request in
+      if let body = request.body {
+        await capture.append(body)
+      }
+
+      return AsyncThrowingStream { continuation in
+        // First turn: reasoning + tool call.
+        continuation.yield(.init(data: #"{"type":"response.output_item.added","item":{"type":"reasoning"}}"#))
+        continuation.yield(.init(data: #"{"type":"response.reasoning_summary_text.delta","delta":"plan"}"#))
+        continuation.yield(.init(data: #"{"type":"response.output_item.done","item":{"type":"reasoning","id":"rs_1","summary":[{"type":"summary_text","text":"plan"}],"encrypted_content":"enc_abc"}}"#))
+
+        continuation.yield(.init(data: #"{"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_1","id":"fc_1","name":"test_tool","arguments":"{\"x\":1}"}}"#))
+        continuation.yield(.init(data: #"{"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_1","id":"fc_1","name":"test_tool","arguments":"{\"x\":1}"}}"#))
+
+        continuation.yield(.init(data: #"{"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}"#))
+        continuation.finish()
+      }
+    })
+
+    let provider = OpenAIResponsesProvider(http: http)
+    let model = Model(id: "gpt-4.1-mini", provider: .openai)
+
+    let firstContext = Context(messages: [.user("hi")])
+    let firstStream = try await provider.stream(model: model, context: firstContext, options: .init(apiKey: apiKey))
+
+    var firstDone: AssistantMessage?
+    for try await event in firstStream {
+      if case let .done(message) = event { firstDone = message }
+    }
+    let assistant1 = try #require(firstDone)
+    #expect(assistant1.content.contains(where: { if case .thinking = $0 { true } else { false } }))
+    #expect(assistant1.content.contains(where: { if case .toolCall = $0 { true } else { false } }))
+
+    let toolResult = ToolResultMessage(
+      toolCallId: "call_1|fc_1",
+      toolName: "test_tool",
+      content: [.text(.init(text: "ok"))],
+      details: .object([:]),
+      isError: false,
+    )
+
+    let secondContext = Context(messages: [
+      .user("hi"),
+      .assistant(assistant1),
+      .toolResult(toolResult),
+      .user("continue"),
+      .assistant(.init(
+        provider: .openai,
+        model: model.id,
+        content: [
+          .thinking(.init(thinking: "plan", signature: reasoningSignature)),
+        ],
+      )),
+    ])
+
+    _ = try await provider.stream(model: model, context: secondContext, options: .init(apiKey: apiKey))
+
+    let secondData = try #require(await capture.last())
+    let secondBody = try #require(try JSONSerialization.jsonObject(with: secondData) as? [String: Any])
+    let input = try #require(secondBody["input"] as? [[String: Any]])
+    let hasReasoning = input.contains(where: { ($0["type"] as? String) == "reasoning" && ($0["id"] as? String) == "rs_1" })
+    #expect(hasReasoning)
+  }
+
+  @Test func omitsToolCallItemIdWhenAssistantModelDiffers() async throws {
+    let apiKey = "sk-test"
+
+    let capture = BodyCapture()
+    let http = MockHTTPClient(sseHandler: { request in
+      if let body = request.body {
+        await capture.append(body)
+      }
+      return AsyncThrowingStream { continuation in
+        continuation.finish()
+      }
+    })
+
+    let provider = OpenAIResponsesProvider(http: http)
+    let currentModel = Model(id: "gpt-4.1-mini", provider: .openai)
+
+    let assistantFromDifferentModel = AssistantMessage(
+      provider: .openai,
+      model: "gpt-4.1",
+      content: [
+        .toolCall(.init(id: "call_1|fc_1", name: "test_tool", arguments: .object([:]))),
+      ],
+    )
+
+    let context = Context(messages: [
+      .user("hi"),
+      .assistant(assistantFromDifferentModel),
+      .toolResult(.init(toolCallId: "call_1|fc_1", toolName: "test_tool", content: [.text("ok")])),
+    ])
+
+    _ = try await provider.stream(model: currentModel, context: context, options: .init(apiKey: apiKey))
+
+    let data = try #require(await capture.last())
+    let body = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let input = try #require(body["input"] as? [[String: Any]])
+    let fc = try #require(input.first(where: { ($0["type"] as? String) == "function_call" }))
+    #expect(fc["call_id"] as? String == "call_1")
+    #expect(fc["id"] == nil)
+  }
+}
+
+private func jsonString(_ obj: [String: Any]) throws -> String {
+  let data = try JSONSerialization.data(withJSONObject: obj, options: [.sortedKeys])
+  return String(decoding: data, as: UTF8.self)
+}
+
+private actor BodyCapture {
+  private var bodies: [Data] = []
+
+  func append(_ data: Data) {
+    bodies.append(data)
+  }
+
+  func last() -> Data? {
+    bodies.last
+  }
 }


### PR DESCRIPTION
Fixes #11.

What changed:
- Capture OpenAI Responses `reasoning` output items during streaming and store them as a `thinking` content block signature.
- Replay those reasoning items in subsequent OpenAI Responses requests so tool-call chains don't fail validation.
- Add `PIAI_OPENAI_STORE` to toggle `store=true` for easier debugging.
- Persist/render the new `thinking` content blocks in Wuhu transcripts.

Tests:
- `swift test`