### PR TITLE
Fix #11: replay OpenAI reasoning items

### DIFF
--- a/Sources/PiAI/Internal/ProviderHelpers.swift
+++ b/Sources/PiAI/Internal/ProviderHelpers.swift
@@ -6,6 +6,18 @@ func resolveAPIKey(_ explicit: String?, env: String, provider: Provider) throws 
   throw PiAIError.missingAPIKey(provider: provider)
 }
 
+func envBool(_ key: String) -> Bool? {
+  guard let raw = ProcessInfo.processInfo.environment[key], !raw.isEmpty else { return nil }
+  switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+  case "1", "true", "t", "yes", "y", "on":
+    return true
+  case "0", "false", "f", "no", "n", "off":
+    return false
+  default:
+    return nil
+  }
+}
+
 func parseJSON(_ text: String) throws -> [String: Any]? {
   let data = Data(text.utf8)
   let obj = try JSONSerialization.jsonObject(with: data)

--- a/Sources/PiAI/Providers/AnthropicMessagesProvider.swift
+++ b/Sources/PiAI/Providers/AnthropicMessagesProvider.swift
@@ -78,6 +78,8 @@ public struct AnthropicMessagesProvider: Sendable {
               "name": call.name,
               "input": call.arguments.toAny(),
             ])
+          case .reasoning:
+            continue
           }
         }
         if !blocks.isEmpty {

--- a/Sources/PiAI/Providers/OpenAICodexResponsesProvider.swift
+++ b/Sources/PiAI/Providers/OpenAICodexResponsesProvider.swift
@@ -68,7 +68,7 @@ public struct OpenAICodexResponsesProvider: Sendable {
     var body: [String: Any] = [
       "model": model.id,
       "stream": true,
-      "store": false,
+      "store": envBool("PIAI_OPENAI_STORE") ?? false,
       "instructions": context.systemPrompt as Any,
       "input": input,
       "text": ["verbosity": "medium"],

--- a/Sources/PiAI/Types.swift
+++ b/Sources/PiAI/Types.swift
@@ -68,9 +68,27 @@ public struct ToolCall: Sendable, Hashable {
   }
 }
 
+/// Provider-specific reasoning content that must be replayed back to the provider in subsequent turns.
+///
+/// Currently used by OpenAI Responses API (`type: "reasoning"` items), where the server may require
+/// historical reasoning items (and their `encrypted_content`) to be included in later requests,
+/// especially when tool calls are involved.
+public struct ReasoningContent: Sendable, Hashable {
+  public var id: String
+  public var encryptedContent: String?
+  public var summary: [JSONValue]
+
+  public init(id: String, encryptedContent: String? = nil, summary: [JSONValue] = []) {
+    self.id = id
+    self.encryptedContent = encryptedContent
+    self.summary = summary
+  }
+}
+
 public enum ContentBlock: Sendable, Hashable {
   case text(TextContent)
   case toolCall(ToolCall)
+  case reasoning(ReasoningContent)
 }
 
 public enum Message: Sendable, Hashable {
@@ -246,6 +264,10 @@ public enum AssistantMessageEvent: Sendable, Hashable {
 public extension ContentBlock {
   static func text(_ text: String, signature: String? = nil) -> ContentBlock {
     .text(.init(text: text, signature: signature))
+  }
+
+  static func reasoning(id: String, encryptedContent: String? = nil) -> ContentBlock {
+    .reasoning(.init(id: id, encryptedContent: encryptedContent))
   }
 }
 

--- a/Sources/WuhuCore/WuhuService.swift
+++ b/Sources/WuhuCore/WuhuService.swift
@@ -182,6 +182,16 @@ public actor WuhuService {
         "name": .string(c.name),
         "arguments": c.arguments,
       ])
+    case let .reasoning(r):
+      var obj: [String: JSONValue] = [
+        "type": .string("reasoning"),
+        "id": .string(r.id),
+        "summary": .array(r.summary),
+      ]
+      if let encrypted = r.encryptedContent {
+        obj["encrypted_content"] = .string(encrypted)
+      }
+      return .object(obj)
     }
   }
 }

--- a/Sources/wuhu/main.swift
+++ b/Sources/wuhu/main.swift
@@ -291,6 +291,8 @@ private func renderBlocks(_ blocks: [WuhuContentBlock]) -> String {
       text
     case let .toolCall(_, name, arguments):
       "[tool_call \(name) args=\(formatJSON(arguments))]"
+    case .reasoning:
+      nil
     }
   }.joined()
 }

--- a/Tests/PiAITests/OpenAIResponsesProviderTests.swift
+++ b/Tests/PiAITests/OpenAIResponsesProviderTests.swift
@@ -39,4 +39,46 @@ struct OpenAIResponsesProviderTests {
     #expect(message.content == [.text(.init(text: "Hello"))])
     #expect(message.usage == Usage(inputTokens: 1, outputTokens: 2, totalTokens: 3))
   }
+
+  @Test func replaysReasoningItemsInRequestBody() async throws {
+    setenv("PIAI_OPENAI_STORE", "true", 1)
+    defer { unsetenv("PIAI_OPENAI_STORE") }
+
+    let apiKey = "sk-test"
+
+    let http = MockHTTPClient(sseHandler: { request in
+      let body = try #require(request.body)
+      let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+      #expect(json["store"] as? Bool == true)
+
+      let input = try #require(json["input"] as? [[String: Any]])
+      let reasoning = input.first(where: { ($0["type"] as? String) == "reasoning" })
+      #expect(reasoning?["id"] as? String == "rsn_1")
+      #expect(reasoning?["encrypted_content"] as? String == "enc_1")
+      #expect((reasoning?["summary"] as? [Any]) != nil)
+
+      return AsyncThrowingStream { continuation in
+        continuation.finish()
+      }
+    })
+
+    let provider = OpenAIResponsesProvider(http: http)
+    let model = Model(id: "gpt-5.2-codex", provider: .openai)
+
+    let assistant = AssistantMessage(provider: .openai, model: model.id, content: [
+      .reasoning(.init(id: "rsn_1", encryptedContent: "enc_1")),
+      .toolCall(.init(id: "call_1|item_1", name: "read", arguments: .object([:]))),
+    ])
+
+    let context = Context(systemPrompt: nil, messages: [
+      .user("Run a tool"),
+      .assistant(assistant),
+      .toolResult(.init(toolCallId: "call_1|item_1", toolName: "read", content: [.text(.init(text: "ok"))])),
+      .user("Continue"),
+    ])
+
+    let stream = try await provider.stream(model: model, context: context, options: .init(apiKey: apiKey, reasoningEffort: .low))
+    for try await _ in stream {}
+  }
 }


### PR DESCRIPTION
Fixes #11.

- Add OpenAI Responses reasoning item capture + replay (including required summary)
- Allow enabling store=true via PIAI_OPENAI_STORE
- Persist reasoning blocks in WuhuCore so sessions can be continued
- Add regression test covering reasoning replay