### PR TITLE
Implement server/runner split (#14)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,7 @@ let package = Package(
     .library(name: "WuhuCore", targets: ["WuhuCore"]),
     .library(name: "WuhuClient", targets: ["WuhuClient"]),
     .library(name: "WuhuServer", targets: ["WuhuServer"]),
+    .library(name: "WuhuRunner", targets: ["WuhuRunner"]),
     .executable(name: "wuhu", targets: ["wuhu"]),
   ],
   dependencies: [
@@ -36,6 +37,7 @@ let package = Package(
     .package(url: "https://github.com/swiftlang/swift-testing.git", from: "6.2.0"),
     .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.27.0"),
     .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
+    .package(url: "https://github.com/hummingbird-project/hummingbird-websocket.git", from: "2.0.0"),
     .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
     grdbDependency,
   ],
@@ -83,6 +85,19 @@ let package = Package(
       dependencies: [
         "WuhuCore",
         .product(name: "Hummingbird", package: "hummingbird"),
+        .product(name: "HummingbirdWebSocket", package: "hummingbird-websocket"),
+        .product(name: "HummingbirdWSClient", package: "hummingbird-websocket"),
+        .product(name: "Yams", package: "Yams"),
+      ],
+      swiftSettings: strictConcurrency,
+    ),
+    .target(
+      name: "WuhuRunner",
+      dependencies: [
+        "WuhuCore",
+        .product(name: "Hummingbird", package: "hummingbird"),
+        .product(name: "HummingbirdWebSocket", package: "hummingbird-websocket"),
+        .product(name: "HummingbirdWSClient", package: "hummingbird-websocket"),
         .product(name: "Yams", package: "Yams"),
       ],
       swiftSettings: strictConcurrency,
@@ -92,7 +107,9 @@ let package = Package(
       dependencies: [
         "WuhuClient",
         "WuhuServer",
+        "WuhuRunner",
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
+        .product(name: "Yams", package: "Yams"),
       ],
       swiftSettings: strictConcurrency,
     ),

--- a/Sources/WuhuAPI/WuhuHTTPModels.swift
+++ b/Sources/WuhuAPI/WuhuHTTPModels.swift
@@ -6,6 +6,7 @@ public struct WuhuCreateSessionRequest: Sendable, Hashable, Codable {
   public var model: String?
   public var systemPrompt: String?
   public var environment: String
+  public var runner: String?
   public var parentSessionID: String?
 
   public init(
@@ -13,12 +14,14 @@ public struct WuhuCreateSessionRequest: Sendable, Hashable, Codable {
     model: String? = nil,
     systemPrompt: String? = nil,
     environment: String,
+    runner: String? = nil,
     parentSessionID: String? = nil,
   ) {
     self.provider = provider
     self.model = model
     self.systemPrompt = systemPrompt
     self.environment = environment
+    self.runner = runner
     self.parentSessionID = parentSessionID
   }
 }

--- a/Sources/WuhuAPI/WuhuRunnerProtocol.swift
+++ b/Sources/WuhuAPI/WuhuRunnerProtocol.swift
@@ -1,0 +1,127 @@
+import Foundation
+import PiAI
+
+public enum WuhuRunnerMessage: Sendable, Hashable, Codable {
+  case hello(runnerName: String, version: Int)
+
+  case resolveEnvironmentRequest(id: String, name: String)
+  case resolveEnvironmentResponse(id: String, environment: WuhuEnvironment?, error: String?)
+
+  case registerSession(sessionID: String, environment: WuhuEnvironment)
+
+  case toolRequest(id: String, sessionID: String, toolCallId: String, toolName: String, args: JSONValue)
+  case toolResponse(id: String, sessionID: String, toolCallId: String, result: WuhuToolResult?, isError: Bool, errorMessage: String?)
+
+  enum CodingKeys: String, CodingKey {
+    case type
+    case id
+    case runnerName
+    case version
+    case name
+    case environment
+    case error
+    case sessionID
+    case toolCallId
+    case toolName
+    case args
+    case result
+    case isError
+    case errorMessage
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    let type = try c.decode(String.self, forKey: .type)
+    switch type {
+    case "hello":
+      self = try .hello(
+        runnerName: c.decode(String.self, forKey: .runnerName),
+        version: c.decode(Int.self, forKey: .version),
+      )
+
+    case "resolve_environment_request":
+      self = try .resolveEnvironmentRequest(
+        id: c.decode(String.self, forKey: .id),
+        name: c.decode(String.self, forKey: .name),
+      )
+
+    case "resolve_environment_response":
+      self = try .resolveEnvironmentResponse(
+        id: c.decode(String.self, forKey: .id),
+        environment: c.decodeIfPresent(WuhuEnvironment.self, forKey: .environment),
+        error: c.decodeIfPresent(String.self, forKey: .error),
+      )
+
+    case "register_session":
+      self = try .registerSession(
+        sessionID: c.decode(String.self, forKey: .sessionID),
+        environment: c.decode(WuhuEnvironment.self, forKey: .environment),
+      )
+
+    case "tool_request":
+      self = try .toolRequest(
+        id: c.decode(String.self, forKey: .id),
+        sessionID: c.decode(String.self, forKey: .sessionID),
+        toolCallId: c.decode(String.self, forKey: .toolCallId),
+        toolName: c.decode(String.self, forKey: .toolName),
+        args: c.decode(JSONValue.self, forKey: .args),
+      )
+
+    case "tool_response":
+      self = try .toolResponse(
+        id: c.decode(String.self, forKey: .id),
+        sessionID: c.decode(String.self, forKey: .sessionID),
+        toolCallId: c.decode(String.self, forKey: .toolCallId),
+        result: c.decodeIfPresent(WuhuToolResult.self, forKey: .result),
+        isError: c.decode(Bool.self, forKey: .isError),
+        errorMessage: c.decodeIfPresent(String.self, forKey: .errorMessage),
+      )
+
+    default:
+      throw DecodingError.dataCorruptedError(forKey: .type, in: c, debugDescription: "Unknown runner message type: \\(type)")
+    }
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var c = encoder.container(keyedBy: CodingKeys.self)
+    switch self {
+    case let .hello(runnerName, version):
+      try c.encode("hello", forKey: .type)
+      try c.encode(runnerName, forKey: .runnerName)
+      try c.encode(version, forKey: .version)
+
+    case let .resolveEnvironmentRequest(id, name):
+      try c.encode("resolve_environment_request", forKey: .type)
+      try c.encode(id, forKey: .id)
+      try c.encode(name, forKey: .name)
+
+    case let .resolveEnvironmentResponse(id, environment, error):
+      try c.encode("resolve_environment_response", forKey: .type)
+      try c.encode(id, forKey: .id)
+      try c.encodeIfPresent(environment, forKey: .environment)
+      try c.encodeIfPresent(error, forKey: .error)
+
+    case let .registerSession(sessionID, environment):
+      try c.encode("register_session", forKey: .type)
+      try c.encode(sessionID, forKey: .sessionID)
+      try c.encode(environment, forKey: .environment)
+
+    case let .toolRequest(id, sessionID, toolCallId, toolName, args):
+      try c.encode("tool_request", forKey: .type)
+      try c.encode(id, forKey: .id)
+      try c.encode(sessionID, forKey: .sessionID)
+      try c.encode(toolCallId, forKey: .toolCallId)
+      try c.encode(toolName, forKey: .toolName)
+      try c.encode(args, forKey: .args)
+
+    case let .toolResponse(id, sessionID, toolCallId, result, isError, errorMessage):
+      try c.encode("tool_response", forKey: .type)
+      try c.encode(id, forKey: .id)
+      try c.encode(sessionID, forKey: .sessionID)
+      try c.encode(toolCallId, forKey: .toolCallId)
+      try c.encodeIfPresent(result, forKey: .result)
+      try c.encode(isError, forKey: .isError)
+      try c.encodeIfPresent(errorMessage, forKey: .errorMessage)
+    }
+  }
+}

--- a/Sources/WuhuAPI/WuhuSession.swift
+++ b/Sources/WuhuAPI/WuhuSession.swift
@@ -6,6 +6,7 @@ public struct WuhuSession: Sendable, Hashable, Codable, Identifiable {
   public var model: String
   public var environment: WuhuEnvironment
   public var cwd: String
+  public var runnerName: String?
   public var parentSessionID: String?
   public var createdAt: Date
   public var updatedAt: Date
@@ -18,6 +19,7 @@ public struct WuhuSession: Sendable, Hashable, Codable, Identifiable {
     model: String,
     environment: WuhuEnvironment,
     cwd: String,
+    runnerName: String? = nil,
     parentSessionID: String?,
     createdAt: Date,
     updatedAt: Date,
@@ -29,6 +31,7 @@ public struct WuhuSession: Sendable, Hashable, Codable, Identifiable {
     self.model = model
     self.environment = environment
     self.cwd = cwd
+    self.runnerName = runnerName
     self.parentSessionID = parentSessionID
     self.createdAt = createdAt
     self.updatedAt = updatedAt

--- a/Sources/WuhuCore/SQLiteSessionStore.swift
+++ b/Sources/WuhuCore/SQLiteSessionStore.swift
@@ -20,6 +20,7 @@ public actor SQLiteSessionStore: SessionStore {
     model: String,
     systemPrompt: String,
     environment: WuhuEnvironment,
+    runnerName: String?,
     parentSessionID: String?,
   ) async throws -> WuhuSession {
     let now = Date()
@@ -34,6 +35,7 @@ public actor SQLiteSessionStore: SessionStore {
         environmentType: environment.type.rawValue,
         environmentPath: environment.path,
         cwd: environment.path,
+        runnerName: runnerName,
         parentSessionID: parentSessionID,
         createdAt: now,
         updatedAt: now,
@@ -194,6 +196,7 @@ private struct SessionRow: Codable, FetchableRecord, MutablePersistableRecord {
   var environmentType: String
   var environmentPath: String
   var cwd: String
+  var runnerName: String?
   var parentSessionID: String?
   var createdAt: Date
   var updatedAt: Date
@@ -216,6 +219,7 @@ private struct SessionRow: Codable, FetchableRecord, MutablePersistableRecord {
       model: model,
       environment: .init(name: environmentName, type: envType, path: environmentPath),
       cwd: cwd,
+      runnerName: runnerName,
       parentSessionID: parentSessionID,
       createdAt: createdAt,
       updatedAt: updatedAt,
@@ -291,6 +295,7 @@ extension SQLiteSessionStore {
         t.column("environmentType", .text).notNull()
         t.column("environmentPath", .text).notNull()
         t.column("cwd", .text).notNull()
+        t.column("runnerName", .text)
         t.column("parentSessionID", .text)
         t.column("createdAt", .datetime).notNull()
         t.column("updatedAt", .datetime).notNull()

--- a/Sources/WuhuCore/SessionStore.swift
+++ b/Sources/WuhuCore/SessionStore.swift
@@ -24,6 +24,7 @@ public protocol SessionStore: Sendable {
     model: String,
     systemPrompt: String,
     environment: WuhuEnvironment,
+    runnerName: String?,
     parentSessionID: String?,
   ) async throws -> WuhuSession
 

--- a/Sources/WuhuCore/WuhuCore.docc/Design/ServerRunner.md
+++ b/Sources/WuhuCore/WuhuCore.docc/Design/ServerRunner.md
@@ -1,0 +1,115 @@
+# Server/Runner Split
+
+This document describes how Wuhu supports **remote tool execution** by splitting the system into:
+
+- **Client**: talks only to the main server (HTTP + SSE)
+- **Server**: runs LLM inference and persists sessions to SQLite
+- **Runner**: executes the coding-agent **tools** (filesystem + shell) on a remote machine
+
+## Goals
+
+- Keep a **single binary** (`wuhu`) that can run as `server`, `client`, or `runner`.
+- Ensure **LLM inference happens only on the main server**.
+- Support two runner deployment modes:
+  - **Runner-as-server**: runner listens on `:5531`; server connects out using `server.yml`.
+  - **Runner-as-client**: runner connects to the server using `wuhu runner --connect-to http://…:5530`.
+- Maintain a **constant number of server↔runner connections** as sessions grow (per runner: one WebSocket connection).
+- Track tool execution by **session id** and **tool call id** (not just “environment”).
+
+## Config Files
+
+After this split, Wuhu supports:
+
+- `~/.wuhu/server.yml` (required for `wuhu server`)
+- `~/.wuhu/runner.yml` (required for `wuhu runner`)
+- `~/.wuhu/client.yml` (optional for `wuhu client`)
+
+### `server.yml` (excerpt)
+
+```yaml
+llm:
+  openai: "…"
+  anthropic: "…"
+environments:
+  - name: wuhu-repo
+    type: local
+    path: /Users/selveskii/Developer/wuhu-swift
+runners:
+  - name: vps-in-la
+    address: 1.2.3.4:5531
+```
+
+### `runner.yml` (excerpt)
+
+```yaml
+name: vps-in-la
+connectTo: http://1.2.3.4:5530 # optional; if set, runner connects to server
+listen:                        # used when connectTo is not set
+  host: 0.0.0.0
+  port: 5531
+databasePath: ~/.wuhu/runner.sqlite
+environments:
+  - name: wuhu-repo
+    type: local
+    path: /home/ubuntu/wuhu-swift
+```
+
+### `client.yml` (optional)
+
+```yaml
+server: http://127.0.0.1:5530
+```
+
+## Server↔Runner Wire Protocol
+
+Server and runner communicate over **WebSocket** using a small JSON protocol:
+
+- Messages are `Codable` (`WuhuRunnerMessage` in `WuhuAPI`).
+- Each request/response pair includes a correlation `id`.
+- Tool execution messages include:
+  - `sessionID` (which session this tool call belongs to)
+  - `toolCallId` (which tool call within the agent loop)
+
+This allows the server to multiplex multiple sessions over a **single WebSocket** per runner.
+
+## Concurrency and Head-of-Line Blocking
+
+Even with one WebSocket per runner, we avoid “tool calls for session A block session B” by:
+
+- Keeping the WebSocket **read loop** independent from tool execution.
+- Executing each tool request in its own task on the runner, and responding when it completes.
+- Correlating responses by `id`, so multiple in-flight tool calls can complete out of order.
+
+### Future: Large File Transfer (Not Implemented)
+
+Large file transfer is intentionally **not handled** in the current design.
+
+If/when needed, the intended approach is:
+
+1. Use WebSocket only to exchange a short-lived **transfer token** + metadata.
+2. Transfer file bytes over a **separate HTTP connection** using that token.
+
+This prevents large payloads from monopolizing the WebSocket channel.
+
+## Session Environment Persistence on the Runner
+
+The server persists an immutable snapshot of the chosen environment into the server database.
+
+For runner sessions, the runner also maintains a small SQLite database (`runner_sessions`) mapping:
+
+- `sessionID` → environment snapshot (`name`, `type`, `path`)
+
+This enables tool execution messages to contain only `sessionID` (no “pwd”/environment identifier required on the wire).
+
+## Database Schema Reuse
+
+Wuhu intentionally keeps **separate databases** for:
+
+- the main server (sessions + transcripts)
+- each runner (sessionID → environment snapshot)
+
+This aligns with the “two migrations, shared models” approach:
+
+- Shared `Codable` models live in `WuhuAPI`.
+- Each component owns its own migrations and db file path.
+

--- a/Sources/WuhuCore/WuhuCore.docc/WuhuCore.md
+++ b/Sources/WuhuCore/WuhuCore.docc/WuhuCore.md
@@ -109,12 +109,11 @@ All public store APIs are `async` to compose naturally with Swift concurrency.
 
 ## CLI Integration
 
-The `wuhu` executable is a thin wrapper around `WuhuService`:
+The `wuhu` executable runs in three modes:
 
-- `wuhu create-session --provider openai` → prints session id
-- `wuhu prompt --session-id <id> <prompt...>` → appends and streams response
-- `wuhu get-session --session-id <id>` → prints metadata + transcript
-- `wuhu list-sessions` → lists sessions
+- `wuhu server` starts the HTTP server (LLM inference + persistence).
+- `wuhu client …` talks to a running server (HTTP + SSE).
+- `wuhu runner` executes coding-agent tools for remote sessions (see the Server/Runner design doc).
 
 ## Future: Forking Sessions (Not Implemented)
 

--- a/Sources/WuhuCore/WuhuService.swift
+++ b/Sources/WuhuCore/WuhuService.swift
@@ -22,6 +22,7 @@ public actor WuhuService {
     model: String,
     systemPrompt: String,
     environment: WuhuEnvironment,
+    runnerName: String? = nil,
     parentSessionID: String? = nil,
   ) async throws -> WuhuSession {
     try await store.createSession(
@@ -29,6 +30,7 @@ public actor WuhuService {
       model: model,
       systemPrompt: systemPrompt,
       environment: environment,
+      runnerName: runnerName,
       parentSessionID: parentSessionID,
     )
   }

--- a/Sources/WuhuRunner/SQLiteRunnerStore.swift
+++ b/Sources/WuhuRunner/SQLiteRunnerStore.swift
@@ -1,0 +1,72 @@
+import Foundation
+import GRDB
+import WuhuAPI
+
+public protocol RunnerStore: Sendable {
+  func upsertSession(sessionID: String, environment: WuhuEnvironment) async throws
+  func getEnvironment(sessionID: String) async throws -> WuhuEnvironment?
+}
+
+public actor SQLiteRunnerStore: RunnerStore {
+  private let dbQueue: DatabaseQueue
+
+  public init(path: String) throws {
+    var config = Configuration()
+    config.busyMode = .timeout(5)
+    dbQueue = try DatabaseQueue(path: path, configuration: config)
+    try Self.migrator.migrate(dbQueue)
+  }
+
+  public func upsertSession(sessionID: String, environment: WuhuEnvironment) async throws {
+    let now = Date()
+    try await dbQueue.write { db in
+      var row = RunnerSessionRow(
+        sessionID: sessionID,
+        environmentName: environment.name,
+        environmentType: environment.type.rawValue,
+        environmentPath: environment.path,
+        createdAt: now,
+        updatedAt: now,
+      )
+      try row.save(db)
+    }
+  }
+
+  public func getEnvironment(sessionID: String) async throws -> WuhuEnvironment? {
+    try await dbQueue.read { db in
+      guard let row = try RunnerSessionRow.fetchOne(db, key: sessionID) else { return nil }
+      guard let type = WuhuEnvironmentType(rawValue: row.environmentType) else { return nil }
+      return .init(name: row.environmentName, type: type, path: row.environmentPath)
+    }
+  }
+}
+
+private struct RunnerSessionRow: Codable, FetchableRecord, MutablePersistableRecord {
+  static let databaseTableName = "runner_sessions"
+
+  var sessionID: String
+  var environmentName: String
+  var environmentType: String
+  var environmentPath: String
+  var createdAt: Date
+  var updatedAt: Date
+}
+
+extension SQLiteRunnerStore {
+  private static let migrator: DatabaseMigrator = {
+    var migrator = DatabaseMigrator()
+
+    migrator.registerMigration("createRunnerSessions_v1") { db in
+      try db.create(table: "runner_sessions") { t in
+        t.column("sessionID", .text).primaryKey()
+        t.column("environmentName", .text).notNull()
+        t.column("environmentType", .text).notNull()
+        t.column("environmentPath", .text).notNull()
+        t.column("createdAt", .datetime).notNull()
+        t.column("updatedAt", .datetime).notNull()
+      }
+    }
+
+    return migrator
+  }()
+}

--- a/Sources/WuhuRunner/WuhuRunner.swift
+++ b/Sources/WuhuRunner/WuhuRunner.swift
@@ -1,0 +1,256 @@
+import Foundation
+import Hummingbird
+import HummingbirdWebSocket
+import Logging
+import WSClient
+import WSCore
+import WuhuAPI
+import WuhuCore
+
+public struct WuhuRunner: Sendable {
+  public init() {}
+
+  public func run(configPath: String?, connectTo overrideConnectTo: String?) async throws {
+    let path = (configPath?.isEmpty == false) ? configPath! : WuhuRunnerConfig.defaultPath()
+    let config = try WuhuRunnerConfig.load(path: path)
+
+    let dbPath: String = {
+      if let p = config.databasePath, !p.isEmpty { return (p as NSString).expandingTildeInPath }
+      let home = FileManager.default.homeDirectoryForCurrentUser
+      return home.appendingPathComponent(".wuhu/runner.sqlite").path
+    }()
+    try ensureDirectoryExists(forDatabasePath: dbPath)
+
+    let store = try SQLiteRunnerStore(path: dbPath)
+
+    let connectTo = (overrideConnectTo?.isEmpty == false) ? overrideConnectTo : config.connectTo
+    if let connectTo, !connectTo.isEmpty {
+      try await runAsClient(runnerName: config.name, connectTo: connectTo, config: config, store: store)
+      return
+    }
+
+    try await runAsServer(runnerName: config.name, config: config, store: store)
+  }
+}
+
+private func runAsServer(
+  runnerName: String,
+  config: WuhuRunnerConfig,
+  store: SQLiteRunnerStore,
+) async throws {
+  let router = RunnerRouter.make(runnerName: runnerName, config: config, store: store)
+
+  let host = config.listen?.host?.isEmpty == false ? config.listen!.host! : "127.0.0.1"
+  let port = config.listen?.port ?? 5531
+
+  let app = Application(
+    router: router,
+    server: .http1WebSocketUpgrade(webSocketRouter: router),
+    configuration: .init(address: .hostname(host, port: port)),
+  )
+  try await app.runService()
+}
+
+private func runAsClient(
+  runnerName: String,
+  connectTo: String,
+  config: WuhuRunnerConfig,
+  store: SQLiteRunnerStore,
+) async throws {
+  let wsURL = wsURLFromHTTP(connectTo, path: "/v1/runners/ws")
+
+  let logger = Logger(label: "WuhuRunner")
+  let client = WebSocketClient(url: wsURL, logger: logger) { inbound, outbound, context in
+    let hello = WuhuRunnerMessage.hello(runnerName: runnerName, version: 1)
+    try await outbound.write(.text(encodeRunnerMessage(hello)))
+    try await RunnerMessageLoop.handle(
+      inbound: inbound,
+      outbound: outbound,
+      logger: context.logger,
+      runnerName: runnerName,
+      config: config,
+      store: store,
+    )
+  }
+  try await client.run()
+}
+
+private enum RunnerRouter {
+  static func make(runnerName: String, config: WuhuRunnerConfig, store: SQLiteRunnerStore) -> Router<RunnerRequestContext> {
+    let router = Router(context: RunnerRequestContext.self)
+
+    router.get("healthz") { _, _ -> String in "ok" }
+
+    router.ws("/v1/runner/ws") { _, _ in
+      .upgrade()
+    } onUpgrade: { inbound, outbound, wsContext in
+      let hello = WuhuRunnerMessage.hello(runnerName: runnerName, version: 1)
+      try await outbound.write(.text(encodeRunnerMessage(hello)))
+      try await RunnerMessageLoop.handle(
+        inbound: inbound,
+        outbound: outbound,
+        logger: wsContext.logger,
+        runnerName: runnerName,
+        config: config,
+        store: store,
+      )
+    }
+
+    return router
+  }
+}
+
+private enum RunnerMessageLoop {
+  static func handle(
+    inbound: WebSocketInboundStream,
+    outbound: WebSocketOutboundWriter,
+    logger: Logger,
+    runnerName _: String,
+    config: WuhuRunnerConfig,
+    store: SQLiteRunnerStore,
+  ) async throws {
+    let sender = WebSocketSender(outbound: outbound)
+
+    for try await message in inbound.messages(maxSize: 16 * 1024 * 1024) {
+      guard case let .text(text) = message else { continue }
+      guard let data = text.data(using: .utf8) else { continue }
+
+      let decoded = try WuhuJSON.decoder.decode(WuhuRunnerMessage.self, from: data)
+      switch decoded {
+      case .hello:
+        continue
+
+      case let .resolveEnvironmentRequest(id, name):
+        let env = resolveEnvironment(config: config, name: name)
+        let response: WuhuRunnerMessage = if let env {
+          .resolveEnvironmentResponse(id: id, environment: env, error: nil)
+        } else {
+          .resolveEnvironmentResponse(id: id, environment: nil, error: "Unknown environment: \(name)")
+        }
+        try await sender.send(response)
+
+      case let .registerSession(sessionID, environment):
+        try await store.upsertSession(sessionID: sessionID, environment: environment)
+
+      case let .toolRequest(id, sessionID, toolCallId, toolName, args):
+        Task {
+          do {
+            let env = try await store.getEnvironment(sessionID: sessionID)
+            guard let env else {
+              try await sender.send(.toolResponse(
+                id: id,
+                sessionID: sessionID,
+                toolCallId: toolCallId,
+                result: nil,
+                isError: true,
+                errorMessage: "Unknown session: \(sessionID)",
+              ))
+              return
+            }
+
+            let tools = WuhuTools.codingAgentTools(cwd: env.path)
+            guard let tool = tools.first(where: { $0.tool.name == toolName }) else {
+              try await sender.send(.toolResponse(
+                id: id,
+                sessionID: sessionID,
+                toolCallId: toolCallId,
+                result: nil,
+                isError: true,
+                errorMessage: "Unknown tool: \(toolName)",
+              ))
+              return
+            }
+
+            let result = try await tool.execute(toolCallId: toolCallId, args: args)
+            let response = WuhuRunnerMessage.toolResponse(
+              id: id,
+              sessionID: sessionID,
+              toolCallId: toolCallId,
+              result: .init(content: result.content.map(WuhuContentBlock.fromPi), details: result.details),
+              isError: false,
+              errorMessage: nil,
+            )
+            try await sender.send(response)
+          } catch {
+            logger.debug("Tool execution failed", metadata: ["error": "\(error)"])
+            try? await sender.send(.toolResponse(
+              id: id,
+              sessionID: sessionID,
+              toolCallId: toolCallId,
+              result: .init(content: [.text(text: String(describing: error), signature: nil)], details: .object([:])),
+              isError: true,
+              errorMessage: String(describing: error),
+            ))
+          }
+        }
+
+      case .resolveEnvironmentResponse, .toolResponse:
+        continue
+      }
+    }
+  }
+
+  private static func resolveEnvironment(config: WuhuRunnerConfig, name: String) -> WuhuEnvironment? {
+    guard let env = config.environments.first(where: { $0.name == name }) else { return nil }
+    guard env.type == "local" else { return nil }
+    let resolvedPath = ToolPath.resolveToCwd(env.path, cwd: FileManager.default.currentDirectoryPath)
+    return .init(name: env.name, type: .local, path: resolvedPath)
+  }
+}
+
+private actor WebSocketSender {
+  private var outbound: WebSocketOutboundWriter
+
+  init(outbound: WebSocketOutboundWriter) {
+    self.outbound = outbound
+  }
+
+  func send(_ message: WuhuRunnerMessage) async throws {
+    try await outbound.write(.text(encodeRunnerMessage(message)))
+  }
+}
+
+private func encodeRunnerMessage(_ message: WuhuRunnerMessage) -> String {
+  let data = try! WuhuJSON.encoder.encode(message)
+  return String(decoding: data, as: UTF8.self)
+}
+
+private func wsURLFromHTTP(_ http: String, path: String) -> String {
+  if http.hasPrefix("https://") {
+    return "wss://" + http.dropFirst("https://".count) + path
+  }
+  if http.hasPrefix("http://") {
+    return "ws://" + http.dropFirst("http://".count) + path
+  }
+  return "ws://\(http)\(path)"
+}
+
+private func ensureDirectoryExists(forDatabasePath path: String) throws {
+  guard path != ":memory:" else { return }
+  let url = URL(fileURLWithPath: path)
+  let dir = url.deletingLastPathComponent()
+  try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+}
+
+private struct RunnerRequestContext: RequestContext, WebSocketRequestContext {
+  var coreContext: CoreRequestContextStorage
+  let webSocket: WebSocketHandlerReference<Self>
+
+  init(source: Source) {
+    coreContext = .init(source: source)
+    webSocket = .init()
+  }
+
+  var requestDecoder: JSONDecoder {
+    let d = JSONDecoder()
+    d.dateDecodingStrategy = .secondsSince1970
+    return d
+  }
+
+  var responseEncoder: JSONEncoder {
+    let e = JSONEncoder()
+    e.outputFormatting = [.sortedKeys]
+    e.dateEncodingStrategy = .secondsSince1970
+    return e
+  }
+}

--- a/Sources/WuhuRunner/WuhuRunnerConfig.swift
+++ b/Sources/WuhuRunner/WuhuRunnerConfig.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Yams
+
+public struct WuhuRunnerConfig: Sendable, Hashable, Codable {
+  public struct Environment: Sendable, Hashable, Codable {
+    public var name: String
+    public var type: String
+    public var path: String
+
+    public init(name: String, type: String, path: String) {
+      self.name = name
+      self.type = type
+      self.path = path
+    }
+  }
+
+  public struct Listen: Sendable, Hashable, Codable {
+    public var host: String?
+    public var port: Int?
+
+    public init(host: String? = nil, port: Int? = nil) {
+      self.host = host
+      self.port = port
+    }
+  }
+
+  public var name: String
+  public var connectTo: String?
+  public var listen: Listen?
+  public var databasePath: String?
+  public var environments: [Environment]
+
+  public init(
+    name: String,
+    connectTo: String? = nil,
+    listen: Listen? = nil,
+    databasePath: String? = nil,
+    environments: [Environment],
+  ) {
+    self.name = name
+    self.connectTo = connectTo
+    self.listen = listen
+    self.databasePath = databasePath
+    self.environments = environments
+  }
+
+  public static func load(path: String) throws -> WuhuRunnerConfig {
+    let expanded = (path as NSString).expandingTildeInPath
+    let text = try String(contentsOfFile: expanded, encoding: .utf8)
+    return try YAMLDecoder().decode(WuhuRunnerConfig.self, from: text)
+  }
+
+  public static func defaultPath() -> String {
+    FileManager.default.homeDirectoryForCurrentUser
+      .appendingPathComponent(".wuhu/runner.yml")
+      .path
+  }
+}

--- a/Sources/WuhuServer/RunnerConnection.swift
+++ b/Sources/WuhuServer/RunnerConnection.swift
@@ -1,0 +1,120 @@
+import Foundation
+import Logging
+import PiAgent
+import PiAI
+import WSCore
+import WuhuAPI
+
+final actor RunnerConnection {
+  let runnerName: String
+
+  private let logger: Logger
+  private var outbound: WebSocketOutboundWriter
+
+  private var pending: [String: CheckedContinuation<WuhuRunnerMessage, any Error>] = [:]
+  private var isClosed: Bool = false
+
+  init(
+    runnerName: String,
+    outbound: WebSocketOutboundWriter,
+    logger: Logger,
+  ) {
+    self.runnerName = runnerName
+    self.outbound = outbound
+    self.logger = logger
+  }
+
+  func close(_ error: any Error = PiAIError.decoding("Runner connection closed")) {
+    guard !isClosed else { return }
+    isClosed = true
+    failAllPending(error)
+  }
+
+  func resolveEnvironment(name: String) async throws -> WuhuEnvironment {
+    let id = UUID().uuidString
+    let response = try await requestResponse(
+      requestId: id,
+      message: .resolveEnvironmentRequest(id: id, name: name),
+    )
+    guard case let .resolveEnvironmentResponse(_, environment, error) = response else {
+      throw PiAIError.decoding("Unexpected response")
+    }
+    if let environment { return environment }
+    throw PiAIError.unsupported(error ?? "Unknown environment")
+  }
+
+  func registerSession(sessionID: String, environment: WuhuEnvironment) async throws {
+    try await send(.registerSession(sessionID: sessionID, environment: environment))
+  }
+
+  func executeTool(
+    sessionID: String,
+    toolCallId: String,
+    toolName: String,
+    args: JSONValue,
+  ) async throws -> AgentToolResult {
+    let id = UUID().uuidString
+    let response = try await requestResponse(
+      requestId: id,
+      message: .toolRequest(id: id, sessionID: sessionID, toolCallId: toolCallId, toolName: toolName, args: args),
+    )
+    guard case let .toolResponse(_, _, _, resultValue, isError, errorMessage) = response else {
+      throw PiAIError.decoding("Unexpected response")
+    }
+    if isError {
+      throw PiAIError.unsupported(errorMessage ?? "Tool execution failed")
+    }
+    let result = resultValue ?? .init(content: [.text(text: "(no output)", signature: nil)], details: .object([:]))
+    return AgentToolResult(
+      content: result.content.map { $0.toPi() },
+      details: result.details,
+    )
+  }
+
+  func handleIncoming(_ message: WuhuRunnerMessage) {
+    switch message {
+    case .hello, .registerSession, .resolveEnvironmentRequest, .toolRequest:
+      return
+    case let .resolveEnvironmentResponse(id, _, _),
+         let .toolResponse(id, _, _, _, _, _):
+      if let cont = pending.removeValue(forKey: id) {
+        cont.resume(returning: message)
+      }
+    }
+  }
+
+  private func requestResponse(
+    requestId: String,
+    message: WuhuRunnerMessage,
+  ) async throws -> WuhuRunnerMessage {
+    try await withCheckedThrowingContinuation { continuation in
+      if isClosed {
+        continuation.resume(throwing: PiAIError.unsupported("Runner '\(runnerName)' is disconnected"))
+        return
+      }
+      pending[requestId] = continuation
+      Task {
+        do {
+          try await self.send(message)
+        } catch {
+          if let cont = pending.removeValue(forKey: requestId) {
+            cont.resume(throwing: error)
+          }
+        }
+      }
+    }
+  }
+
+  private func send(_ message: WuhuRunnerMessage) async throws {
+    let data = try WuhuJSON.encoder.encode(message)
+    let text = String(decoding: data, as: UTF8.self)
+    try await outbound.write(.text(text))
+  }
+
+  private func failAllPending(_ error: any Error) {
+    for (_, cont) in pending {
+      cont.resume(throwing: error)
+    }
+    pending.removeAll()
+  }
+}

--- a/Sources/WuhuServer/RunnerRegistry.swift
+++ b/Sources/WuhuServer/RunnerRegistry.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Logging
+import PiAI
+import WSClient
+import WSCore
+import WuhuAPI
+
+actor RunnerRegistry {
+  private var connections: [String: RunnerConnection] = [:]
+
+  func set(_ connection: RunnerConnection, for runnerName: String? = nil) {
+    connections[runnerName ?? connection.runnerName] = connection
+  }
+
+  func remove(runnerName: String) {
+    connections.removeValue(forKey: runnerName)
+  }
+
+  func get(runnerName: String) -> RunnerConnection? {
+    connections[runnerName]
+  }
+
+  func connectToRunnerServer(runner: WuhuServerConfig.Runner, logger: Logger) async throws {
+    let wsURL = wsURLFromAddress(runner.address, path: "/v1/runner/ws")
+
+    let client = WebSocketClient(url: wsURL, logger: logger) { inbound, outbound, context in
+      do {
+        try await self.handleSocket(
+          inbound: inbound,
+          outbound: outbound,
+          logger: context.logger,
+          expectedRunnerName: runner.name,
+        )
+      } catch {
+        context.logger.error(
+          "Runner WebSocket connection failed",
+          metadata: ["runner": "\(runner.name)", "error": "\(error)"],
+        )
+      }
+    }
+
+    try await client.run()
+  }
+
+  func acceptRunnerClient(
+    inbound: WebSocketInboundStream,
+    outbound: WebSocketOutboundWriter,
+    logger: Logger,
+  ) async throws {
+    try await handleSocket(
+      inbound: inbound,
+      outbound: outbound,
+      logger: logger,
+      expectedRunnerName: nil,
+    )
+  }
+
+  private func handleSocket(
+    inbound: WebSocketInboundStream,
+    outbound: WebSocketOutboundWriter,
+    logger: Logger,
+    expectedRunnerName: String?,
+  ) async throws {
+    var iterator = inbound.messages(maxSize: 16 * 1024 * 1024).makeAsyncIterator()
+
+    guard let helloMessage = try await iterator.next() else {
+      throw PiAIError.decoding("Runner WebSocket closed before hello")
+    }
+    guard case let .text(helloText) = helloMessage, let helloData = helloText.data(using: .utf8) else {
+      throw PiAIError.decoding("Runner hello must be a text WebSocket message")
+    }
+    let hello = try WuhuJSON.decoder.decode(WuhuRunnerMessage.self, from: helloData)
+    guard case let .hello(actualName, version) = hello else {
+      throw PiAIError.decoding("First runner message must be hello")
+    }
+    guard version == 1 else {
+      throw PiAIError.unsupported("Unsupported runner protocol version \(version)")
+    }
+
+    if let expectedRunnerName, expectedRunnerName != actualName {
+      throw PiAIError.unsupported("Runner name mismatch (expected '\(expectedRunnerName)', got '\(actualName)')")
+    }
+
+    let registeredName = expectedRunnerName ?? actualName
+    let connection = RunnerConnection(runnerName: registeredName, outbound: outbound, logger: logger)
+    set(connection, for: registeredName)
+
+    defer {
+      remove(runnerName: registeredName)
+      Task { await connection.close(PiAIError.decoding("Runner WebSocket closed")) }
+    }
+
+    while let message = try await iterator.next() {
+      guard case let .text(text) = message else { continue }
+      guard let data = text.data(using: .utf8) else { continue }
+      do {
+        let decoded = try WuhuJSON.decoder.decode(WuhuRunnerMessage.self, from: data)
+        await connection.handleIncoming(decoded)
+      } catch {
+        logger.debug("Failed to decode runner message", metadata: ["runner": "\(registeredName)", "error": "\(error)"])
+      }
+    }
+  }
+}
+
+private func wsURLFromAddress(_ address: String, path: String) -> String {
+  if address.hasPrefix("ws://") || address.hasPrefix("wss://") {
+    return address + path
+  }
+  return "ws://\(address)\(path)"
+}

--- a/Sources/WuhuServer/WuhuRemoteTools.swift
+++ b/Sources/WuhuServer/WuhuRemoteTools.swift
@@ -1,0 +1,27 @@
+import Foundation
+import PiAgent
+import PiAI
+import WuhuCore
+
+enum WuhuRemoteTools {
+  static func makeTools(
+    sessionID: String,
+    runnerName: String,
+    runnerRegistry: RunnerRegistry,
+  ) -> [AnyAgentTool] {
+    let baseTools = WuhuTools.codingAgentTools(cwd: "/")
+    return baseTools.map { base in
+      AnyAgentTool(tool: base.tool, label: base.label) { toolCallId, args in
+        guard let runner = await runnerRegistry.get(runnerName: runnerName) else {
+          throw PiAIError.unsupported("Runner '\(runnerName)' is disconnected")
+        }
+        return try await runner.executeTool(
+          sessionID: sessionID,
+          toolCallId: toolCallId,
+          toolName: base.tool.name,
+          args: args,
+        )
+      }
+    }
+  }
+}

--- a/Sources/WuhuServer/WuhuRequestContext.swift
+++ b/Sources/WuhuServer/WuhuRequestContext.swift
@@ -1,11 +1,14 @@
 import Foundation
 import Hummingbird
+import HummingbirdWebSocket
 
-struct WuhuRequestContext: RequestContext {
+struct WuhuRequestContext: RequestContext, WebSocketRequestContext {
   var coreContext: CoreRequestContextStorage
+  let webSocket: WebSocketHandlerReference<Self>
 
   init(source: Source) {
     coreContext = .init(source: source)
+    webSocket = .init()
   }
 
   var requestDecoder: JSONDecoder {

--- a/Sources/WuhuServer/WuhuServerConfig.swift
+++ b/Sources/WuhuServer/WuhuServerConfig.swift
@@ -24,8 +24,20 @@ public struct WuhuServerConfig: Sendable, Hashable, Codable {
     }
   }
 
+  public struct Runner: Sendable, Hashable, Codable {
+    public var name: String
+    /// Host:port for the runner WebSocket server (e.g. `1.2.3.4:5531`).
+    public var address: String
+
+    public init(name: String, address: String) {
+      self.name = name
+      self.address = address
+    }
+  }
+
   public var llm: LLM?
   public var environments: [Environment]
+  public var runners: [Runner]?
   public var databasePath: String?
   public var host: String?
   public var port: Int?
@@ -33,12 +45,14 @@ public struct WuhuServerConfig: Sendable, Hashable, Codable {
   public init(
     llm: LLM? = nil,
     environments: [Environment],
+    runners: [Runner]? = nil,
     databasePath: String? = nil,
     host: String? = nil,
     port: Int? = nil,
   ) {
     self.llm = llm
     self.environments = environments
+    self.runners = runners
     self.databasePath = databasePath
     self.host = host
     self.port = port

--- a/Tests/WuhuServerTests/WuhuRunnerProtocolTests.swift
+++ b/Tests/WuhuServerTests/WuhuRunnerProtocolTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+import WuhuAPI
+
+struct WuhuRunnerProtocolTests {
+  @Test func runnerMessageJSONRoundTrip() throws {
+    let toolResult = WuhuToolResult(
+      content: [.text(text: "ok", signature: nil)],
+      details: .object(["exitCode": .number(0)]),
+    )
+
+    let messages: [WuhuRunnerMessage] = [
+      .hello(runnerName: "vps-in-la", version: 1),
+      .resolveEnvironmentRequest(id: "req-1", name: "repo"),
+      .resolveEnvironmentResponse(
+        id: "req-1",
+        environment: .init(name: "repo", type: .local, path: "/tmp/repo"),
+        error: nil,
+      ),
+      .registerSession(sessionID: "sess-1", environment: .init(name: "repo", type: .local, path: "/tmp/repo")),
+      .toolRequest(
+        id: "req-2",
+        sessionID: "sess-1",
+        toolCallId: "tool-1",
+        toolName: "ls",
+        args: .object(["path": .string("."), "limit": .number(20)]),
+      ),
+      .toolResponse(
+        id: "req-2",
+        sessionID: "sess-1",
+        toolCallId: "tool-1",
+        result: toolResult,
+        isError: false,
+        errorMessage: nil,
+      ),
+      .toolResponse(
+        id: "req-3",
+        sessionID: "sess-1",
+        toolCallId: "tool-2",
+        result: nil,
+        isError: true,
+        errorMessage: "Unknown tool",
+      ),
+    ]
+
+    for message in messages {
+      let data = try WuhuJSON.encoder.encode(message)
+      let decoded = try WuhuJSON.decoder.decode(WuhuRunnerMessage.self, from: data)
+      #expect(decoded == message)
+    }
+  }
+}


### PR DESCRIPTION
Implements remote runner support (Issue #14) on top of the existing server/client split.

Key changes:
- Adds `WuhuRunner` target + `wuhu runner` CLI subcommand (runner-as-server and runner-as-client).
- Adds a multiplexed WebSocket protocol (`WuhuRunnerMessage`) for server↔runner tool execution.
- Server keeps LLM inference locally; runner only executes coding-agent tools.
- Adds `--runner` to `wuhu client create-session` and persists `runnerName` on sessions.
- Runner persists a small SQLite mapping `sessionID -> environment` so tool calls only need `sessionID`.
- Adds optional `~/.wuhu/client.yml` support.
- DocC: `ServerRunner.md` design notes (HOL concerns + future file transfer token idea).

Verification:
- `swift test`
- Manual: validated client→server→runner for both runner-as-server and runner-as-client, including exercising all coding-agent tools.
