### PR TITLE
Fix #23: session id via WUHU_CURRENT_SESSION_ID

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -153,5 +153,13 @@ let package = Package(
       ],
       swiftSettings: strictConcurrency,
     ),
+    .testTarget(
+      name: "WuhuCLITests",
+      dependencies: [
+        "wuhu",
+        .product(name: "Testing", package: "swift-testing"),
+      ],
+      swiftSettings: strictConcurrency,
+    ),
   ],
 )

--- a/Tests/WuhuCLITests/WuhuCLITests.swift
+++ b/Tests/WuhuCLITests/WuhuCLITests.swift
@@ -1,0 +1,21 @@
+import ArgumentParser
+import Testing
+@testable import wuhu
+
+struct WuhuCLITests {
+  @Test func resolveWuhuSessionId_prefersOptionOverEnv() throws {
+    let resolved = try resolveWuhuSessionId("opt_123", env: ["WUHU_CURRENT_SESSION_ID": "env_456"])
+    #expect(resolved == "opt_123")
+  }
+
+  @Test func resolveWuhuSessionId_usesEnvWhenOptionMissing() throws {
+    let resolved = try resolveWuhuSessionId(nil, env: ["WUHU_CURRENT_SESSION_ID": "env_456"])
+    #expect(resolved == "env_456")
+  }
+
+  @Test func resolveWuhuSessionId_throwsWhenMissing() {
+    #expect(throws: ValidationError.self) {
+      _ = try resolveWuhuSessionId(nil, env: [:])
+    }
+  }
+}


### PR DESCRIPTION
Closes #23.

- `wuhu client prompt` and `wuhu client get-session` now accept session id from `WUHU_CURRENT_SESSION_ID` when `--session-id` is omitted.
- Adds CLI-level unit tests for the resolver.