### PR TITLE
Basic AGENTS.md support

### DIFF
--- a/Sources/WuhuCore/AgentsContext.swift
+++ b/Sources/WuhuCore/AgentsContext.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+struct WuhuContextFileSnapshot: Sendable, Hashable {
+  var path: String
+  var modifiedAt: Date
+  var size: UInt64
+}
+
+struct WuhuContextFile: Sendable, Hashable {
+  var path: String
+  var content: String
+}
+
+enum WuhuAgentsContextFormatter {
+  static func render(files: [WuhuContextFile]) -> String {
+    guard !files.isEmpty else { return "" }
+
+    var s = "\n\n# Project Context\n\n"
+    s += "Project-specific instructions and guidelines:\n\n"
+    for f in files {
+      s += "## \(f.path)\n\n"
+      s += f.content
+      if !s.hasSuffix("\n") { s += "\n" }
+      s += "\n"
+    }
+    return s
+  }
+}
+
+actor WuhuAgentsContextActor {
+  private let cwd: String
+
+  private var cachedSnapshot: [WuhuContextFileSnapshot]?
+  private var cachedRendered: String?
+
+  init(cwd: String) {
+    self.cwd = cwd
+  }
+
+  func contextSection() -> String {
+    let candidates = [
+      URL(fileURLWithPath: cwd).appendingPathComponent("AGENTS.md").path,
+      URL(fileURLWithPath: cwd).appendingPathComponent("AGENTS.local.md").path,
+    ]
+
+    let (snapshots, files) = Self.loadFilesIfChanged(candidates: candidates, cachedSnapshot: cachedSnapshot)
+    if let snapshots {
+      cachedSnapshot = snapshots
+      cachedRendered = WuhuAgentsContextFormatter.render(files: files)
+    }
+
+    return cachedRendered ?? ""
+  }
+
+  private static func loadFilesIfChanged(
+    candidates: [String],
+    cachedSnapshot: [WuhuContextFileSnapshot]?,
+  ) -> (snapshots: [WuhuContextFileSnapshot]?, files: [WuhuContextFile]) {
+    var snapshots: [WuhuContextFileSnapshot] = []
+    snapshots.reserveCapacity(candidates.count)
+
+    for path in candidates {
+      do {
+        let attrs = try FileManager.default.attributesOfItem(atPath: path)
+        guard let type = attrs[.type] as? FileAttributeType, type == .typeRegular else { continue }
+        guard let modifiedAt = attrs[.modificationDate] as? Date else { continue }
+
+        let size: UInt64 = if let n = attrs[.size] as? NSNumber {
+          n.uint64Value
+        } else {
+          0
+        }
+
+        snapshots.append(.init(path: path, modifiedAt: modifiedAt, size: size))
+      } catch {
+        continue
+      }
+    }
+
+    snapshots.sort { $0.path < $1.path }
+
+    if let cachedSnapshot, cachedSnapshot == snapshots {
+      return (snapshots: nil, files: [])
+    }
+
+    var files: [WuhuContextFile] = []
+    files.reserveCapacity(snapshots.count)
+
+    for snap in snapshots {
+      do {
+        let content = try String(contentsOfFile: snap.path, encoding: .utf8)
+        files.append(.init(path: snap.path, content: content))
+      } catch {
+        continue
+      }
+    }
+
+    return (snapshots: snapshots, files: files)
+  }
+}

--- a/Sources/WuhuCore/WuhuCore.docc/Design/ContextFiles.md
+++ b/Sources/WuhuCore/WuhuCore.docc/Design/ContextFiles.md
@@ -1,0 +1,43 @@
+# Context Files (AGENTS.md)
+
+Wuhu supports injecting project context files into the **LLM system prompt** at runtime.
+
+## Files
+
+For each session, Wuhu looks in the session’s working directory (`WuhuSession.cwd`) for:
+
+- `AGENTS.md`
+- `AGENTS.local.md`
+
+Either file may be missing; if both are missing, nothing is injected.
+
+## Injection Format
+
+When present, files are appended to the effective system prompt as a single section:
+
+- `# Project Context`
+- one `## <absolute filepath>` heading per file, followed by the file’s raw contents
+
+This ensures the model can attribute each instruction to a specific file path.
+
+## Persistence (Non-Goal)
+
+Context file contents are **not** persisted into the session transcript in SQLite.
+
+Instead, they are loaded and concatenated dynamically right before calling LLM providers. This keeps the persisted chain (header + messages + tool executions + compactions) free of filesystem-dependent prompt material.
+
+Because the injection is dynamic:
+
+- If the server restarts, the loaded context may differ (e.g., files changed on disk).
+- If a session’s in-memory actor is evicted, it will reload context on next use.
+
+Preserving an identical injected context across restarts/evictions is intentionally a non-goal for v1.
+
+## Caching
+
+Context files are cached **in memory** per session via a per-session context actor managed by `WuhuService`.
+
+- Cache key: session id (actor lifetime)
+- Reload trigger: file set or `(mtime, size)` snapshot changes
+- Eviction: least-recently-used when the server exceeds a small fixed number of cached session actors
+

--- a/Tests/WuhuCoreTests/AgentsContextTests.swift
+++ b/Tests/WuhuCoreTests/AgentsContextTests.swift
@@ -1,0 +1,166 @@
+import Foundation
+import Testing
+import WuhuCore
+
+struct AgentsContextTests {
+  private func makeTempDir(prefix: String) throws -> String {
+    let base = FileManager.default.temporaryDirectory
+    let dir = base.appendingPathComponent("\(prefix)-\(UUID().uuidString.lowercased())", isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true, attributes: nil)
+    return dir.path
+  }
+
+  private func textContent(_ message: Message) -> String {
+    switch message {
+    case let .user(u):
+      u.content.compactMap { if case let .text(t) = $0 { return t.text }; return nil }.joined(separator: "\n")
+    case let .assistant(a):
+      a.content.compactMap { if case let .text(t) = $0 { return t.text }; return nil }.joined(separator: "\n")
+    case let .toolResult(t):
+      t.content.compactMap { if case let .text(x) = $0 { return x.text }; return nil }.joined(separator: "\n")
+    }
+  }
+
+  @Test func promptStreamInjectsAgentsContextIntoSystemPromptButDoesNotPersistIt() async throws {
+    let dir = try makeTempDir(prefix: "wuhu-agents")
+    let agentsMdPath = URL(fileURLWithPath: dir).appendingPathComponent("AGENTS.md").path
+    let agentsLocalPath = URL(fileURLWithPath: dir).appendingPathComponent("AGENTS.local.md").path
+
+    let agentsMdContent = "# AGENTS.md\n\n- speak like yoda\n"
+    let agentsLocalContent = "# AGENTS.local.md\n\n- local override\n"
+    try agentsMdContent.write(toFile: agentsMdPath, atomically: true, encoding: .utf8)
+    try agentsLocalContent.write(toFile: agentsLocalPath, atomically: true, encoding: .utf8)
+
+    let store = try SQLiteSessionStore(path: ":memory:")
+    let service = WuhuService(store: store)
+
+    let session = try await service.createSession(
+      provider: .openai,
+      model: "mock",
+      systemPrompt: "Base prompt.",
+      environment: .init(name: "test", type: .local, path: dir),
+    )
+
+    actor Capture {
+      var systemPrompt: String?
+      func set(_ s: String?) {
+        systemPrompt = s
+      }
+
+      func get() -> String? {
+        systemPrompt
+      }
+    }
+    let capture = Capture()
+
+    let stream = try await service.promptStream(
+      sessionID: session.id,
+      input: "hello",
+      tools: [],
+      streamFn: { model, ctx, _ in
+        await capture.set(ctx.systemPrompt)
+        return AsyncThrowingStream { continuation in
+          Task {
+            let assistant = AssistantMessage(
+              provider: model.provider,
+              model: model.id,
+              content: [.text("ok")],
+              stopReason: .stop,
+            )
+            continuation.yield(.done(message: assistant))
+            continuation.finish()
+          }
+        }
+      },
+    )
+
+    for try await _ in stream {}
+
+    let sp = try #require(await capture.get())
+    #expect(sp.contains("# Project Context"))
+    #expect(sp.contains("## \(agentsMdPath)"))
+    #expect(sp.contains("## \(agentsLocalPath)"))
+    #expect(sp.contains("speak like yoda"))
+    #expect(sp.contains("local override"))
+
+    // Not persisted: header prompt unchanged and injected text not stored as messages.
+    let transcript = try await service.getTranscript(sessionID: session.id)
+    guard let headerEntry = transcript.first, case let .header(header) = headerEntry.payload else {
+      #expect(Bool(false))
+      return
+    }
+    #expect(header.systemPrompt == "Base prompt.")
+
+    let combined = transcript.compactMap { entry -> String? in
+      guard case let .message(m) = entry.payload else { return nil }
+      guard let pi = m.toPiMessage() else { return nil }
+      return textContent(pi)
+    }.joined(separator: "\n")
+
+    #expect(!combined.contains("speak like yoda"))
+    #expect(!combined.contains("local override"))
+  }
+
+  @Test func agentsContextReloadsWhenFilesChange() async throws {
+    let dir = try makeTempDir(prefix: "wuhu-agents-change")
+    let agentsMdPath = URL(fileURLWithPath: dir).appendingPathComponent("AGENTS.md").path
+
+    try "v1".write(toFile: agentsMdPath, atomically: true, encoding: .utf8)
+
+    let store = try SQLiteSessionStore(path: ":memory:")
+    let service = WuhuService(store: store)
+
+    let session = try await service.createSession(
+      provider: .openai,
+      model: "mock",
+      systemPrompt: "Base prompt.",
+      environment: .init(name: "test", type: .local, path: dir),
+    )
+
+    actor Capture {
+      var prompts: [String] = []
+      func add(_ s: String?) {
+        if let s { prompts.append(s) }
+      }
+
+      func all() -> [String] {
+        prompts
+      }
+    }
+    let capture = Capture()
+
+    func runOnce() async throws {
+      let stream = try await service.promptStream(
+        sessionID: session.id,
+        input: "hello",
+        tools: [],
+        streamFn: { model, ctx, _ in
+          await capture.add(ctx.systemPrompt)
+          return AsyncThrowingStream { continuation in
+            Task {
+              let assistant = AssistantMessage(
+                provider: model.provider,
+                model: model.id,
+                content: [.text("ok")],
+                stopReason: .stop,
+              )
+              continuation.yield(.done(message: assistant))
+              continuation.finish()
+            }
+          }
+        },
+      )
+      for try await _ in stream {}
+    }
+
+    try await runOnce()
+
+    try "v2 (changed)".write(toFile: agentsMdPath, atomically: true, encoding: .utf8)
+    try await runOnce()
+
+    let prompts = await capture.all()
+    #expect(prompts.count == 2)
+    #expect(prompts[0].contains("v1"))
+    #expect(prompts[1].contains("v2 (changed)"))
+  }
+}


### PR DESCRIPTION
Closes #20.

- Injects `AGENTS.md` and `AGENTS.local.md` from `WuhuSession.cwd` into the effective system prompt, prefixed by absolute filepath headings.
- Keeps injected context out of the SQLite transcript; it is assembled dynamically right before LLM calls.
- Adds per-session in-memory caching via a per-session context actor, with small LRU eviction in `WuhuService`.
- Docs: `Sources/WuhuCore/WuhuCore.docc/Design/ContextFiles.md`.
- Tests: `Tests/WuhuCoreTests/AgentsContextTests.swift`.

Manual test:
- Added a temporary `AGENTS.local.md` with a “YODA_OK” prefix rule and confirmed the assistant output was prefixed as instructed.