### PR TITLE
Attach to a session: follow mode, cursors, detach

### DIFF
--- a/Sources/WuhuClient/WuhuClient.swift
+++ b/Sources/WuhuClient/WuhuClient.swift
@@ -12,7 +12,7 @@ public struct WuhuClient: Sendable {
   }
 
   public func createSession(_ request: WuhuCreateSessionRequest) async throws -> WuhuSession {
-    let url = baseURL.appending(path: "v1").appending(path: "sessions")
+    let url = baseURL.appending(path: "v2").appending(path: "sessions")
     var req = HTTPRequest(url: url, method: "POST")
     req.setHeader("application/json", for: "Content-Type")
     req.body = try WuhuJSON.encoder.encode(request)
@@ -22,7 +22,7 @@ public struct WuhuClient: Sendable {
   }
 
   public func listSessions(limit: Int? = nil) async throws -> [WuhuSession] {
-    var url = baseURL.appending(path: "v1").appending(path: "sessions")
+    var url = baseURL.appending(path: "v2").appending(path: "sessions")
     if let limit {
       var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
       components?.queryItems = [URLQueryItem(name: "limit", value: String(limit))]
@@ -34,8 +34,20 @@ public struct WuhuClient: Sendable {
     return try WuhuJSON.decoder.decode([WuhuSession].self, from: data)
   }
 
-  public func getSession(id: String) async throws -> WuhuGetSessionResponse {
-    let url = baseURL.appending(path: "v1").appending(path: "sessions").appending(path: id)
+  public func getSession(
+    id: String,
+    sinceCursor: Int64? = nil,
+    sinceTime: Date? = nil,
+  ) async throws -> WuhuGetSessionResponse {
+    var url = baseURL.appending(path: "v2").appending(path: "sessions").appending(path: id)
+    if sinceCursor != nil || sinceTime != nil {
+      var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+      var items: [URLQueryItem] = []
+      if let sinceCursor { items.append(.init(name: "sinceCursor", value: String(sinceCursor))) }
+      if let sinceTime { items.append(.init(name: "sinceTime", value: String(sinceTime.timeIntervalSince1970))) }
+      components?.queryItems = items.isEmpty ? nil : items
+      url = components?.url ?? url
+    }
     let req = HTTPRequest(url: url, method: "GET")
     let (data, _) = try await http.data(for: req)
     return try WuhuJSON.decoder.decode(WuhuGetSessionResponse.self, from: data)
@@ -44,12 +56,12 @@ public struct WuhuClient: Sendable {
   public func promptStream(
     sessionID: String,
     input: String,
-  ) async throws -> AsyncThrowingStream<WuhuPromptEvent, any Error> {
-    let url = baseURL.appending(path: "v1").appending(path: "sessions").appending(path: sessionID).appending(path: "prompt")
+  ) async throws -> AsyncThrowingStream<WuhuSessionStreamEvent, any Error> {
+    let url = baseURL.appending(path: "v2").appending(path: "sessions").appending(path: sessionID).appending(path: "prompt")
     var req = HTTPRequest(url: url, method: "POST")
     req.setHeader("application/json", for: "Content-Type")
     req.setHeader("text/event-stream", for: "Accept")
-    req.body = try WuhuJSON.encoder.encode(WuhuPromptRequest(input: input))
+    req.body = try WuhuJSON.encoder.encode(WuhuPromptRequest(input: input, detach: false))
 
     let sse = try await http.sse(for: req)
     return AsyncThrowingStream { continuation in
@@ -57,7 +69,61 @@ public struct WuhuClient: Sendable {
         do {
           for try await message in sse {
             guard let data = message.data.data(using: .utf8) else { continue }
-            let event = try WuhuJSON.decoder.decode(WuhuPromptEvent.self, from: data)
+            let event = try WuhuJSON.decoder.decode(WuhuSessionStreamEvent.self, from: data)
+            continuation.yield(event)
+            if case .done = event { break }
+          }
+          continuation.finish()
+        } catch {
+          continuation.finish(throwing: error)
+        }
+      }
+
+      continuation.onTermination = { _ in
+        task.cancel()
+      }
+    }
+  }
+
+  public func promptDetached(
+    sessionID: String,
+    input: String,
+  ) async throws -> WuhuPromptDetachedResponse {
+    let url = baseURL.appending(path: "v2").appending(path: "sessions").appending(path: sessionID).appending(path: "prompt")
+    var req = HTTPRequest(url: url, method: "POST")
+    req.setHeader("application/json", for: "Content-Type")
+    req.setHeader("application/json", for: "Accept")
+    req.body = try WuhuJSON.encoder.encode(WuhuPromptRequest(input: input, detach: true))
+
+    let (data, _) = try await http.data(for: req)
+    return try WuhuJSON.decoder.decode(WuhuPromptDetachedResponse.self, from: data)
+  }
+
+  public func followSessionStream(
+    sessionID: String,
+    sinceCursor: Int64? = nil,
+    sinceTime: Date? = nil,
+    stopAfterIdle: Bool? = nil,
+    timeoutSeconds: Double? = nil,
+  ) async throws -> AsyncThrowingStream<WuhuSessionStreamEvent, any Error> {
+    var url = baseURL.appending(path: "v2").appending(path: "sessions").appending(path: sessionID).appending(path: "follow")
+    var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+    var items: [URLQueryItem] = []
+    if let sinceCursor { items.append(.init(name: "sinceCursor", value: String(sinceCursor))) }
+    if let sinceTime { items.append(.init(name: "sinceTime", value: String(sinceTime.timeIntervalSince1970))) }
+    if let stopAfterIdle { items.append(.init(name: "stopAfterIdle", value: stopAfterIdle ? "1" : "0")) }
+    if let timeoutSeconds { items.append(.init(name: "timeoutSeconds", value: String(timeoutSeconds))) }
+    components?.queryItems = items.isEmpty ? nil : items
+    url = components?.url ?? url
+
+    let req = HTTPRequest(url: url, method: "GET")
+    let sse = try await http.sse(for: req)
+    return AsyncThrowingStream { continuation in
+      let task = Task {
+        do {
+          for try await message in sse {
+            guard let data = message.data.data(using: .utf8) else { continue }
+            let event = try WuhuJSON.decoder.decode(WuhuSessionStreamEvent.self, from: data)
             continuation.yield(event)
             if case .done = event { break }
           }

--- a/Sources/WuhuCore/SessionStore.swift
+++ b/Sources/WuhuCore/SessionStore.swift
@@ -34,4 +34,9 @@ public protocol SessionStore: Sendable {
   @discardableResult
   func appendEntry(sessionID: String, payload: WuhuEntryPayload) async throws -> WuhuSessionEntry
   func getEntries(sessionID: String) async throws -> [WuhuSessionEntry]
+  func getEntries(
+    sessionID: String,
+    sinceCursor: Int64?,
+    sinceTime: Date?,
+  ) async throws -> [WuhuSessionEntry]
 }

--- a/Sources/WuhuCore/WuhuCore.docc/Design/SessionFollow.md
+++ b/Sources/WuhuCore/WuhuCore.docc/Design/SessionFollow.md
@@ -1,0 +1,65 @@
+# Attaching / Following a Session
+
+Wuhu supports “attach” / “follow” workflows where a client subscribes to **live session changes**:
+
+- a coding agent’s in-flight progress (assistant text deltas)
+- persisted transcript updates (new prompts, messages, tool executions, compactions)
+
+This is implemented without external brokers: Wuhu is a single process with a single SQLite database, so it can use an in-process fanout.
+
+## Cursor Model
+
+Every persisted session entry has:
+
+- a monotonically increasing SQLite `id` (`INTEGER PRIMARY KEY AUTOINCREMENT`)
+- `createdAt` (unix timestamp)
+
+The entry `id` is the **cursor**.
+
+Both the `prompt` and `get-session` commands surface these cursors so coding agents can safely poll/attach using:
+
+- `--since-cursor <id>` to request updates since the last observed entry
+- `--since-time <time>` when time-based filtering is preferred
+
+## HTTP API
+
+### Non-follow (query)
+
+- `GET /v2/sessions/:id?sinceCursor=…&sinceTime=…`
+
+Returns `WuhuGetSessionResponse` where `transcript` is filtered by the optional cursor/time constraints.
+
+### Follow (SSE)
+
+- `GET /v2/sessions/:id/follow?sinceCursor=…&sinceTime=…&stopAfterIdle=1&timeoutSeconds=…`
+
+Returns `text/event-stream` where each `data:` frame is a JSON-encoded `WuhuSessionStreamEvent`.
+
+## Event Types
+
+The event stream includes:
+
+- `entry_appended` — a persisted `WuhuSessionEntry` (includes cursor + timestamp)
+- `assistant_text_delta` — in-flight assistant progress (not persisted as individual DB rows)
+- `idle` — the session transitioned from “running” → “idle”
+- `done` — server closed the stream (stop condition or timeout)
+
+## Stop Conditions
+
+Follow mode supports stopping:
+
+- when the session becomes idle (`stopAfterIdle=1`)
+- after a wall-clock timeout (`timeoutSeconds`)
+
+The CLI defaults to `stopAfterIdle` if no timeout is provided, which is convenient for coding agents that “attach to the current run and return when it’s done”.
+
+## Race-Free Catch-up
+
+To avoid missing events when switching from “query the DB” → “subscribe to live events”, the server:
+
+1. subscribes to the live event fanout (buffering a small window)
+2. reads the initial filtered entries from SQLite
+3. forwards buffered/live events, skipping already-delivered cursors
+
+This yields “tail -f”-like behavior without introducing a message queue.
+

--- a/Sources/WuhuCore/WuhuService.swift
+++ b/Sources/WuhuCore/WuhuService.swift
@@ -3,18 +3,14 @@ import PiAgent
 import PiAI
 import WuhuAPI
 
-public enum WuhuPromptStreamEvent: Sendable, Hashable {
-  case toolExecutionStart(toolCallId: String, toolName: String, args: JSONValue)
-  case toolExecutionEnd(toolCallId: String, toolName: String, result: AgentToolResult, isError: Bool)
-  case assistantTextDelta(String)
-  case done
-}
-
 public actor WuhuService {
   private let store: any SessionStore
   private var sessionContextActors: [String: WuhuAgentsContextActor] = [:]
   private var sessionContextActorLastAccess: [String: Date] = [:]
   private let maxSessionContextActors = 64
+
+  private var liveSubscribers: [String: [UUID: AsyncStream<WuhuSessionStreamEvent>.Continuation]] = [:]
+  private var activePromptCount: [String: Int] = [:]
 
   public init(store: any SessionStore) {
     self.store = store
@@ -50,12 +46,20 @@ public actor WuhuService {
     try await store.getEntries(sessionID: sessionID)
   }
 
+  public func getTranscript(
+    sessionID: String,
+    sinceCursor: Int64?,
+    sinceTime: Date?,
+  ) async throws -> [WuhuSessionEntry] {
+    try await store.getEntries(sessionID: sessionID, sinceCursor: sinceCursor, sinceTime: sinceTime)
+  }
+
   public func promptStream(
     sessionID: String,
     input: String,
     tools: [AnyAgentTool]? = nil,
     streamFn: @escaping StreamFn = PiAI.streamSimple,
-  ) async throws -> AsyncThrowingStream<WuhuPromptStreamEvent, any Error> {
+  ) async throws -> AsyncThrowingStream<WuhuSessionStreamEvent, any Error> {
     let session = try await store.getSession(id: sessionID)
     var transcript = try await store.getEntries(sessionID: sessionID)
 
@@ -101,9 +105,17 @@ public actor WuhuService {
       streamFn: streamFn,
     ))
 
-    return AsyncThrowingStream(WuhuPromptStreamEvent.self, bufferingPolicy: .bufferingNewest(1024)) { continuation in
+    beginPrompt(sessionID: sessionID)
+    let userEntry = try await store.appendEntry(sessionID: sessionID, payload: .message(.fromPi(.user(input))))
+    publishLiveEvent(sessionID: sessionID, event: .entryAppended(userEntry))
+
+    return AsyncThrowingStream(WuhuSessionStreamEvent.self, bufferingPolicy: .bufferingNewest(1024)) { continuation in
       let task = Task {
         do {
+          defer { Task { await self.endPrompt(sessionID: sessionID) } }
+
+          continuation.yield(.entryAppended(userEntry))
+
           let consumeTask = Task {
             for try await event in agent.events {
               try await self.handleAgentEvent(event, sessionID: sessionID, continuation: continuation)
@@ -124,6 +136,151 @@ public actor WuhuService {
       continuation.onTermination = { _ in
         task.cancel()
         Task { await agent.abort() }
+        Task { await self.endPrompt(sessionID: sessionID) }
+      }
+    }
+  }
+
+  public func promptDetached(
+    sessionID: String,
+    input: String,
+    tools: [AnyAgentTool]? = nil,
+    streamFn: @escaping StreamFn = PiAI.streamSimple,
+  ) async throws -> WuhuPromptDetachedResponse {
+    let session = try await store.getSession(id: sessionID)
+    var transcript = try await store.getEntries(sessionID: sessionID)
+
+    let header = try Self.extractHeader(from: transcript, sessionID: sessionID)
+    let model = Model(id: session.model, provider: session.provider.piProvider)
+
+    let resolvedTools = tools ?? WuhuTools.codingAgentTools(cwd: session.cwd)
+
+    var effectiveSystemPrompt = header.systemPrompt
+    let injectedContext = await sessionContextActor(for: sessionID, cwd: session.cwd).contextSection()
+    if !injectedContext.isEmpty {
+      effectiveSystemPrompt += injectedContext
+    }
+    effectiveSystemPrompt += "\n\nWorking directory: \(session.cwd)\nAll relative paths are resolved from this directory."
+
+    var requestOptions = RequestOptions()
+    if model.provider == .openai, model.id.contains("gpt-5") || model.id.contains("codex") {
+      requestOptions.reasoningEffort = .low
+    }
+
+    let compactionSettings = WuhuCompactionSettings.load(model: model)
+    transcript = try await maybeAutoCompact(
+      sessionID: sessionID,
+      transcript: transcript,
+      model: model,
+      requestOptions: requestOptions,
+      compactionSettings: compactionSettings,
+      input: input,
+      streamFn: streamFn,
+    )
+
+    let messages = Self.extractContextMessages(from: transcript)
+
+    let agent = PiAgent.Agent(opts: .init(
+      initialState: .init(
+        systemPrompt: effectiveSystemPrompt,
+        model: model,
+        tools: resolvedTools,
+        messages: messages,
+      ),
+      requestOptions: requestOptions,
+      streamFn: streamFn,
+    ))
+
+    beginPrompt(sessionID: sessionID)
+    let userEntry = try await store.appendEntry(sessionID: sessionID, payload: .message(.fromPi(.user(input))))
+    publishLiveEvent(sessionID: sessionID, event: .entryAppended(userEntry))
+
+    Task {
+      do {
+        defer { Task { await self.endPrompt(sessionID: sessionID) } }
+
+        let consumeTask = Task {
+          do {
+            for try await event in agent.events {
+              try await self.handleAgentEvent(event, sessionID: sessionID, continuation: nil)
+              if case .agentEnd = event { break }
+            }
+          } catch {
+            // Best-effort: detached prompts don't surface errors to a caller.
+          }
+        }
+        defer { consumeTask.cancel() }
+
+        try await agent.prompt(input)
+        _ = try await consumeTask.value
+      } catch {
+        await agent.abort()
+      }
+    }
+
+    return WuhuPromptDetachedResponse(userEntry: userEntry)
+  }
+
+  public func followSessionStream(
+    sessionID: String,
+    sinceCursor: Int64?,
+    sinceTime: Date?,
+    stopAfterIdle: Bool,
+    timeoutSeconds: Double?,
+  ) async throws -> AsyncThrowingStream<WuhuSessionStreamEvent, any Error> {
+    let live = subscribeLiveEvents(sessionID: sessionID)
+    let initial = try await store.getEntries(sessionID: sessionID, sinceCursor: sinceCursor, sinceTime: sinceTime)
+    let lastInitialCursor = initial.last?.id ?? sinceCursor ?? 0
+    let initiallyIdle = isIdle(sessionID: sessionID)
+
+    return AsyncThrowingStream(WuhuSessionStreamEvent.self, bufferingPolicy: .bufferingNewest(4096)) { continuation in
+      let forwardTask = Task {
+        do {
+          for entry in initial {
+            continuation.yield(.entryAppended(entry))
+          }
+
+          if stopAfterIdle, initiallyIdle {
+            continuation.yield(.idle)
+            continuation.yield(.done)
+            continuation.finish()
+            return
+          }
+
+          for await event in live {
+            switch event {
+            case let .entryAppended(entry):
+              if entry.id <= lastInitialCursor { continue }
+              continuation.yield(event)
+            case .assistantTextDelta, .idle:
+              continuation.yield(event)
+              if stopAfterIdle, case .idle = event {
+                continuation.yield(.done)
+                continuation.finish()
+                return
+              }
+            case .done:
+              // Should not be published to live subscribers.
+              break
+            }
+          }
+
+          continuation.finish()
+        }
+      }
+
+      let timeoutTask: Task<Void, Never>? = timeoutSeconds.flatMap { seconds in
+        Task {
+          let ns = UInt64(max(0, seconds) * 1_000_000_000)
+          try? await Task.sleep(nanoseconds: ns)
+          continuation.yield(.done)
+          continuation.finish()
+        }
+      }
+
+      continuation.onTermination = { _ in
+        forwardTask.cancel()
+        timeoutTask?.cancel()
       }
     }
   }
@@ -160,11 +317,12 @@ public actor WuhuService {
         streamFn: streamFn,
       )
 
-      _ = try await store.appendEntry(sessionID: sessionID, payload: .compaction(.init(
+      let entry = try await store.appendEntry(sessionID: sessionID, payload: .compaction(.init(
         summary: summary,
         tokensBefore: preparation.tokensBefore,
         firstKeptEntryID: preparation.firstKeptEntryID,
       )))
+      publishLiveEvent(sessionID: sessionID, event: .entryAppended(entry))
 
       current = try await store.getEntries(sessionID: sessionID)
     }
@@ -175,21 +333,21 @@ public actor WuhuService {
   private func handleAgentEvent(
     _ event: AgentEvent,
     sessionID: String,
-    continuation: AsyncThrowingStream<WuhuPromptStreamEvent, any Error>.Continuation,
+    continuation: AsyncThrowingStream<WuhuSessionStreamEvent, any Error>.Continuation?,
   ) async throws {
     switch event {
     case let .toolExecutionStart(toolCallId, toolName, args):
-      continuation.yield(.toolExecutionStart(toolCallId: toolCallId, toolName: toolName, args: args))
-      try await store.appendEntry(sessionID: sessionID, payload: .toolExecution(.init(
+      let entry = try await store.appendEntry(sessionID: sessionID, payload: .toolExecution(.init(
         phase: .start,
         toolCallId: toolCallId,
         toolName: toolName,
         arguments: args,
       )))
+      publishLiveEvent(sessionID: sessionID, event: .entryAppended(entry))
+      continuation?.yield(.entryAppended(entry))
 
     case let .toolExecutionEnd(toolCallId, toolName, result, isError):
-      continuation.yield(.toolExecutionEnd(toolCallId: toolCallId, toolName: toolName, result: result, isError: isError))
-      try await store.appendEntry(sessionID: sessionID, payload: .toolExecution(.init(
+      let entry = try await store.appendEntry(sessionID: sessionID, payload: .toolExecution(.init(
         phase: .end,
         toolCallId: toolCallId,
         toolName: toolName,
@@ -200,14 +358,22 @@ public actor WuhuService {
         ]),
         isError: isError,
       )))
+      publishLiveEvent(sessionID: sessionID, event: .entryAppended(entry))
+      continuation?.yield(.entryAppended(entry))
 
     case let .messageUpdate(message, assistantEvent):
       if case .assistant = message, case let .textDelta(delta, _) = assistantEvent {
-        continuation.yield(.assistantTextDelta(delta))
+        publishLiveEvent(sessionID: sessionID, event: .assistantTextDelta(delta))
+        continuation?.yield(.assistantTextDelta(delta))
       }
 
     case let .messageEnd(message):
-      try await store.appendEntry(sessionID: sessionID, payload: .message(.fromPi(message)))
+      if case .user = message {
+        break
+      }
+      let entry = try await store.appendEntry(sessionID: sessionID, payload: .message(.fromPi(message)))
+      publishLiveEvent(sessionID: sessionID, event: .entryAppended(entry))
+      continuation?.yield(.entryAppended(entry))
 
     default:
       break
@@ -311,5 +477,52 @@ public actor WuhuService {
 
     sessionContextActors.removeValue(forKey: oldestSessionID)
     sessionContextActorLastAccess.removeValue(forKey: oldestSessionID)
+  }
+
+  private func subscribeLiveEvents(sessionID: String) -> AsyncStream<WuhuSessionStreamEvent> {
+    AsyncStream(WuhuSessionStreamEvent.self, bufferingPolicy: .bufferingNewest(4096)) { continuation in
+      let token = UUID()
+      liveSubscribers[sessionID, default: [:]][token] = continuation
+      continuation.onTermination = { _ in
+        Task { await self.removeLiveSubscriber(sessionID: sessionID, token: token) }
+      }
+    }
+  }
+
+  private func removeLiveSubscriber(sessionID: String, token: UUID) {
+    liveSubscribers[sessionID]?[token] = nil
+    if liveSubscribers[sessionID]?.isEmpty == true {
+      liveSubscribers[sessionID] = nil
+    }
+  }
+
+  private func publishLiveEvent(sessionID: String, event: WuhuSessionStreamEvent) {
+    guard var sessionSubs = liveSubscribers[sessionID], !sessionSubs.isEmpty else { return }
+    for (token, continuation) in sessionSubs {
+      continuation.yield(event)
+      sessionSubs[token] = continuation
+    }
+    liveSubscribers[sessionID] = sessionSubs
+  }
+
+  private func beginPrompt(sessionID: String) {
+    let n = (activePromptCount[sessionID] ?? 0) + 1
+    activePromptCount[sessionID] = n
+  }
+
+  private func endPrompt(sessionID: String) {
+    let old = activePromptCount[sessionID] ?? 0
+    if old == 0 { return }
+    let n = max(0, old - 1)
+    if n == 0 {
+      activePromptCount[sessionID] = nil
+      publishLiveEvent(sessionID: sessionID, event: .idle)
+    } else {
+      activePromptCount[sessionID] = n
+    }
+  }
+
+  private func isIdle(sessionID: String) -> Bool {
+    (activePromptCount[sessionID] ?? 0) == 0
   }
 }

--- a/Sources/WuhuRunner/WuhuRunner.swift
+++ b/Sources/WuhuRunner/WuhuRunner.swift
@@ -57,7 +57,7 @@ private func runAsClient(
   config: WuhuRunnerConfig,
   store: SQLiteRunnerStore,
 ) async throws {
-  let wsURL = wsURLFromHTTP(connectTo, path: "/v1/runners/ws")
+  let wsURL = wsURLFromHTTP(connectTo, path: "/v2/runners/ws")
 
   let logger = Logger(label: "WuhuRunner")
   let client = WebSocketClient(url: wsURL, logger: logger) { inbound, outbound, context in
@@ -81,7 +81,7 @@ private enum RunnerRouter {
 
     router.get("healthz") { _, _ -> String in "ok" }
 
-    router.ws("/v1/runner/ws") { _, _ in
+    router.ws("/v2/runner/ws") { _, _ in
       .upgrade()
     } onUpgrade: { inbound, outbound, wsContext in
       let hello = WuhuRunnerMessage.hello(runnerName: runnerName, version: 1)

--- a/Sources/WuhuServer/RunnerRegistry.swift
+++ b/Sources/WuhuServer/RunnerRegistry.swift
@@ -21,7 +21,7 @@ actor RunnerRegistry {
   }
 
   func connectToRunnerServer(runner: WuhuServerConfig.Runner, logger: Logger) async throws {
-    let wsURL = wsURLFromAddress(runner.address, path: "/v1/runner/ws")
+    let wsURL = wsURLFromAddress(runner.address, path: "/v2/runner/ws")
 
     let client = WebSocketClient(url: wsURL, logger: logger) { inbound, outbound, context in
       do {

--- a/Tests/WuhuClientTests/WuhuClientTests.swift
+++ b/Tests/WuhuClientTests/WuhuClientTests.swift
@@ -8,7 +8,7 @@ struct WuhuClientTests {
   @Test func promptStreamDecodesSSEEvents() async throws {
     let http = MockHTTPClient(
       sseHandler: { request in
-        #expect(request.url.absoluteString == "http://127.0.0.1:5530/v1/sessions/s1/prompt")
+        #expect(request.url.absoluteString == "http://127.0.0.1:5530/v2/sessions/s1/prompt")
         #expect(request.headers["Accept"] == "text/event-stream")
         #expect(request.headers["Content-Type"] == "application/json")
 

--- a/Tests/WuhuCoreTests/WuhuCoreTests.swift
+++ b/Tests/WuhuCoreTests/WuhuCoreTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PiAI
 import Testing
 import WuhuCore
 #if canImport(Darwin)
@@ -232,5 +233,131 @@ struct WuhuCoreTests {
         }
       }
     }
+  }
+
+  @Test func getTranscript_sinceCursorAndSinceTimeFilters() async throws {
+    let store = try SQLiteSessionStore(path: ":memory:")
+    let service = WuhuService(store: store)
+
+    let session = try await service.createSession(
+      provider: .openai,
+      model: "mock",
+      systemPrompt: "You are helpful.",
+      environment: .init(name: "test", type: .local, path: "/tmp"),
+    )
+
+    let e1 = try await store.appendEntry(sessionID: session.id, payload: .message(.fromPi(.user("one"))))
+    let e2 = try await store.appendEntry(sessionID: session.id, payload: .message(.fromPi(.assistant(.init(
+      provider: .openai,
+      model: "mock",
+      content: [.text("two")],
+      stopReason: .stop,
+    )))))
+
+    let sinceCursor = try await service.getTranscript(sessionID: session.id, sinceCursor: e1.id, sinceTime: nil)
+    #expect(sinceCursor.map(\.id) == [e2.id])
+
+    let sinceTimeFuture = try await service.getTranscript(
+      sessionID: session.id,
+      sinceCursor: nil,
+      sinceTime: Date().addingTimeInterval(60),
+    )
+    #expect(sinceTimeFuture.isEmpty)
+  }
+
+  @Test func followSessionStream_stopAfterIdleFinishesAfterPromptCompletes() async throws {
+    let store = try SQLiteSessionStore(path: ":memory:")
+    let service = WuhuService(store: store)
+
+    let session = try await service.createSession(
+      provider: .openai,
+      model: "mock",
+      systemPrompt: "You are helpful.",
+      environment: .init(name: "test", type: .local, path: "/tmp"),
+    )
+
+    let slowStream: @Sendable (Model, Context, RequestOptions) -> AsyncThrowingStream<AssistantMessageEvent, any Error> = { model, _, _ in
+      AsyncThrowingStream { continuation in
+        Task {
+          var text = ""
+          let base = AssistantMessage(provider: model.provider, model: model.id, content: [.text("")], stopReason: .stop)
+          continuation.yield(.start(partial: base))
+          for ch in ["H", "i"] {
+            try await Task.sleep(nanoseconds: 80_000_000)
+            text += ch
+            let partial = AssistantMessage(provider: model.provider, model: model.id, content: [.text(text)], stopReason: .stop)
+            continuation.yield(.textDelta(delta: ch, partial: partial))
+          }
+          try await Task.sleep(nanoseconds: 80_000_000)
+          let done = AssistantMessage(provider: model.provider, model: model.id, content: [.text(text)], stopReason: .stop)
+          continuation.yield(.done(message: done))
+          continuation.finish()
+        }
+      }
+    }
+
+    let detached = try await service.promptDetached(
+      sessionID: session.id,
+      input: "hello",
+      tools: [],
+      streamFn: slowStream,
+    )
+
+    let follow = try await service.followSessionStream(
+      sessionID: session.id,
+      sinceCursor: detached.userEntry.id,
+      sinceTime: nil,
+      stopAfterIdle: true,
+      timeoutSeconds: 5,
+    )
+
+    var sawDelta = false
+    var sawIdle = false
+    var sawDone = false
+
+    for try await event in follow {
+      switch event {
+      case .assistantTextDelta:
+        sawDelta = true
+      case .idle:
+        sawIdle = true
+      case .done:
+        sawDone = true
+      default:
+        break
+      }
+    }
+
+    #expect(sawDelta)
+    #expect(sawIdle)
+    #expect(sawDone)
+  }
+
+  @Test func followSessionStream_timeoutFinishes() async throws {
+    let store = try SQLiteSessionStore(path: ":memory:")
+    let service = WuhuService(store: store)
+
+    let session = try await service.createSession(
+      provider: .openai,
+      model: "mock",
+      systemPrompt: "You are helpful.",
+      environment: .init(name: "test", type: .local, path: "/tmp"),
+    )
+
+    let follow = try await service.followSessionStream(
+      sessionID: session.id,
+      sinceCursor: nil,
+      sinceTime: nil,
+      stopAfterIdle: false,
+      timeoutSeconds: 0.2,
+    )
+
+    var sawDone = false
+    for try await event in follow {
+      if case .done = event {
+        sawDone = true
+      }
+    }
+    #expect(sawDone)
   }
 }


### PR DESCRIPTION
Closes #22.

What's in this PR:
- Adds cursor/time display for User/Agent messages in `get-session` output.
- Adds `--since-cursor` and `--since-time` filters to `wuhu client get-session`.
- Adds `--follow` mode for `get-session`, with stop conditions (idle/timeout).
- Adds `--detach` to `wuhu client prompt`.
- Upgrades HTTP API to `v2` and adds `GET /v2/sessions/:id/follow` SSE.
- Adds unit tests for transcript filtering + follow stop conditions.
- Updates DocC design docs (`ServerClient.md`, `SessionFollow.md`).

Validation:
- `swift test`
- `swift package --allow-writing-to-package-directory swiftformat --lint .`
