### PR TITLE
Client identity and group chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@ swift run wuhu list-sessions
 ```
 
 The CLI reads `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` from the environment and will also load a local `.env` if present.
+
+Client identity:
+
+- `wuhu client prompt` sends an optional `user` (username) with each prompt.
+- Configure via `WUHU_USERNAME` or `~/.wuhu/client.yml` `username:` (defaults to `<osuser>@<hostname>`).

--- a/Sources/WuhuAPI/WuhuHTTPModels.swift
+++ b/Sources/WuhuAPI/WuhuHTTPModels.swift
@@ -28,10 +28,12 @@ public struct WuhuCreateSessionRequest: Sendable, Hashable, Codable {
 
 public struct WuhuPromptRequest: Sendable, Hashable, Codable {
   public var input: String
+  public var user: String?
   public var detach: Bool?
 
-  public init(input: String, detach: Bool? = nil) {
+  public init(input: String, user: String? = nil, detach: Bool? = nil) {
     self.input = input
+    self.user = user
     self.detach = detach
   }
 }

--- a/Sources/WuhuAPI/WuhuPersistedMessage.swift
+++ b/Sources/WuhuAPI/WuhuPersistedMessage.swift
@@ -104,16 +104,40 @@ public struct WuhuUsage: Sendable, Hashable, Codable {
 }
 
 public struct WuhuUserMessage: Sendable, Hashable, Codable {
+  public static let unknownUser = "unknown_user"
+
+  public var user: String
   public var content: [WuhuContentBlock]
   public var timestamp: Date
 
-  public init(content: [WuhuContentBlock], timestamp: Date) {
+  public init(user: String = Self.unknownUser, content: [WuhuContentBlock], timestamp: Date) {
+    self.user = user
     self.content = content
     self.timestamp = timestamp
   }
 
+  enum CodingKeys: String, CodingKey {
+    case user
+    case content
+    case timestamp
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    user = try c.decodeIfPresent(String.self, forKey: .user) ?? Self.unknownUser
+    content = try c.decode([WuhuContentBlock].self, forKey: .content)
+    timestamp = try c.decode(Date.self, forKey: .timestamp)
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var c = encoder.container(keyedBy: CodingKeys.self)
+    try c.encode(user, forKey: .user)
+    try c.encode(content, forKey: .content)
+    try c.encode(timestamp, forKey: .timestamp)
+  }
+
   public static func fromPi(_ m: UserMessage) -> WuhuUserMessage {
-    .init(content: m.content.map(WuhuContentBlock.fromPi), timestamp: m.timestamp)
+    .init(user: unknownUser, content: m.content.map(WuhuContentBlock.fromPi), timestamp: m.timestamp)
   }
 
   public func toPi() -> UserMessage {

--- a/Sources/WuhuClient/WuhuClient.swift
+++ b/Sources/WuhuClient/WuhuClient.swift
@@ -56,12 +56,13 @@ public struct WuhuClient: Sendable {
   public func promptStream(
     sessionID: String,
     input: String,
+    user: String? = nil,
   ) async throws -> AsyncThrowingStream<WuhuSessionStreamEvent, any Error> {
     let url = baseURL.appending(path: "v2").appending(path: "sessions").appending(path: sessionID).appending(path: "prompt")
     var req = HTTPRequest(url: url, method: "POST")
     req.setHeader("application/json", for: "Content-Type")
     req.setHeader("text/event-stream", for: "Accept")
-    req.body = try WuhuJSON.encoder.encode(WuhuPromptRequest(input: input, detach: false))
+    req.body = try WuhuJSON.encoder.encode(WuhuPromptRequest(input: input, user: user, detach: false))
 
     let sse = try await http.sse(for: req)
     return AsyncThrowingStream { continuation in
@@ -88,12 +89,13 @@ public struct WuhuClient: Sendable {
   public func promptDetached(
     sessionID: String,
     input: String,
+    user: String? = nil,
   ) async throws -> WuhuPromptDetachedResponse {
     let url = baseURL.appending(path: "v2").appending(path: "sessions").appending(path: sessionID).appending(path: "prompt")
     var req = HTTPRequest(url: url, method: "POST")
     req.setHeader("application/json", for: "Content-Type")
     req.setHeader("application/json", for: "Accept")
-    req.body = try WuhuJSON.encoder.encode(WuhuPromptRequest(input: input, detach: true))
+    req.body = try WuhuJSON.encoder.encode(WuhuPromptRequest(input: input, user: user, detach: true))
 
     let (data, _) = try await http.data(for: req)
     return try WuhuJSON.decoder.decode(WuhuPromptDetachedResponse.self, from: data)

--- a/Sources/WuhuCore/GroupChat.swift
+++ b/Sources/WuhuCore/GroupChat.swift
@@ -1,0 +1,57 @@
+import Foundation
+import PiAI
+import WuhuAPI
+
+enum WuhuGroupChat {
+  static let reminderCustomType = "wuhu_group_chat_reminder_v1"
+
+  static func reminderEntryIndex(in transcript: [WuhuSessionEntry]) -> Int? {
+    transcript.lastIndex { entry in
+      guard case let .message(m) = entry.payload else { return false }
+      guard case let .customMessage(c) = m else { return false }
+      return c.customType == reminderCustomType
+    }
+  }
+
+  static func reminderText(previousUser: String) -> String {
+    """
+    A new user has joined this conversation. From now on, every user message will be prefixed with the user's name.
+    Previously, you have been discussing with \(previousUser).
+    """
+  }
+
+  static func makeReminderMessage(previousUser: String, timestamp: Date = Date()) -> WuhuPersistedMessage {
+    .customMessage(.init(
+      customType: reminderCustomType,
+      content: [.text(text: reminderText(previousUser: previousUser), signature: nil)],
+      details: .object([
+        "previous_user": .string(previousUser),
+        "version": .number(1),
+      ]),
+      display: true,
+      timestamp: timestamp,
+    ))
+  }
+
+  static func renderPromptInput(user: String, input: String) -> String {
+    "\(user):\n\n\(input)"
+  }
+
+  static func renderForLLM(
+    message: WuhuPersistedMessage,
+    entryIndex: Int,
+    reminderIndex: Int?,
+  ) -> Message? {
+    let shouldPrefix = reminderIndex != nil && entryIndex > reminderIndex!
+
+    switch message {
+    case let .user(u) where shouldPrefix:
+      let prefix = ContentBlock.text(.init(text: "\(u.user):\n\n"))
+      let blocks = [prefix] + u.content.map { $0.toPi() }
+      return .user(.init(content: blocks, timestamp: u.timestamp))
+
+    default:
+      return message.toPiMessage()
+    }
+  }
+}

--- a/Sources/WuhuCore/WuhuCore.docc/Design/ServerRunner.md
+++ b/Sources/WuhuCore/WuhuCore.docc/Design/ServerRunner.md
@@ -58,6 +58,7 @@ environments:
 
 ```yaml
 server: http://127.0.0.1:5530
+username: alice@my-mac # optional; also supports env var WUHU_USERNAME
 ```
 
 ## Server↔Runner Wire Protocol
@@ -112,4 +113,3 @@ This aligns with the “two migrations, shared models” approach:
 
 - Shared `Codable` models live in `WuhuAPI`.
 - Each component owns its own migrations and db file path.
-

--- a/Sources/WuhuCore/WuhuCore.docc/WuhuCore.md
+++ b/Sources/WuhuCore/WuhuCore.docc/WuhuCore.md
@@ -92,6 +92,10 @@ All entry payloads are stored as JSON and decoded into `WuhuEntryPayload`:
 - `custom_message` (reserved for extensions; participates in context like a user message)
 - `unknown`
 
+User messages persist an additional identity field:
+
+- `WuhuUserMessage.user` (defaults to `unknown_user` for historical data / missing clients)
+
 This deliberately leaves space for:
 
 - “new entry” types (via `custom` / `unknown`)

--- a/Sources/WuhuServer/WuhuServer.swift
+++ b/Sources/WuhuServer/WuhuServer.swift
@@ -129,6 +129,7 @@ public struct WuhuServer: Sendable {
         let response = try await service.promptDetached(
           sessionID: id,
           input: prompt.input,
+          user: prompt.user,
           tools: tools,
         )
         return try context.responseEncoder.encode(response, from: request, context: context)
@@ -137,6 +138,7 @@ public struct WuhuServer: Sendable {
       let stream: AsyncThrowingStream<WuhuSessionStreamEvent, any Error> = try await service.promptStream(
         sessionID: id,
         input: prompt.input,
+        user: prompt.user,
         tools: tools,
       )
 

--- a/Tests/WuhuCLITests/WuhuCLITests.swift
+++ b/Tests/WuhuCLITests/WuhuCLITests.swift
@@ -18,4 +18,14 @@ struct WuhuCLITests {
       _ = try resolveWuhuSessionId(nil, env: [:])
     }
   }
+
+  @Test func resolveWuhuUsername_prefersOptionOverEnv() {
+    let resolved = resolveWuhuUsername("opt_user", env: ["WUHU_USERNAME": "env_user"])
+    #expect(resolved == "opt_user")
+  }
+
+  @Test func resolveWuhuUsername_usesEnvWhenOptionMissing() {
+    let resolved = resolveWuhuUsername(nil, env: ["WUHU_USERNAME": "env_user"])
+    #expect(resolved == "env_user")
+  }
 }


### PR DESCRIPTION
Fixes #24

## Summary
- Add client identity (`user`) to `POST /v2/sessions/:id/prompt` and persist it as `WuhuUserMessage.user` (defaults to `unknown_user` for historical/missing clients).
- Add CLI username resolution via `--username`, `WUHU_USERNAME`, `~/.wuhu/client.yml` `username`, else `<osuser>@<hostname>`.
- Implement server-side group chat escalation: on first prompt from a second distinct user, append a system reminder entry and prefix subsequent user messages in the LLM-rendered context as `[username]:

<message>` without mutating earlier messages.

## Testing
- `swift test`
- Manual: ran `wuhu server` + `wuhu client prompt` with two different `WUHU_USERNAME` values and verified the system reminder + per-user labels in `get-session` output.