### PR TITLE
Add folder-template environment type

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,8 @@ Client identity:
 
 - `wuhu client prompt` sends an optional `user` (username) with each prompt.
 - Configure via `WUHU_USERNAME` or `~/.wuhu/client.yml` `username:` (defaults to `<osuser>@<hostname>`).
+
+Environments (from `~/.wuhu/server.yml` / `~/.wuhu/runner.yml`):
+
+- `local`: use a fixed working directory (`path`).
+- `folder-template`: copy a template folder (`path`) into `workspaces_path/<session-id>` and optionally run `startup_script` in the copied workspace.

--- a/Sources/WuhuAPI/WuhuEnvironment.swift
+++ b/Sources/WuhuAPI/WuhuEnvironment.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public enum WuhuEnvironmentType: String, Sendable, Codable, Hashable {
   case local
+  case folderTemplate = "folder-template"
 }
 
 /// A snapshot of an environment definition persisted with a session.
@@ -11,12 +12,24 @@ public enum WuhuEnvironmentType: String, Sendable, Codable, Hashable {
 public struct WuhuEnvironment: Sendable, Hashable, Codable {
   public var name: String
   public var type: WuhuEnvironmentType
-  /// Absolute path for `local` environments.
+  /// Absolute path used as the working directory for tools (session `cwd`).
   public var path: String
+  /// For `folder-template` environments, the absolute path to the template folder used to create `path`.
+  public var templatePath: String?
+  /// For `folder-template` environments, an optional startup script executed in the copied workspace.
+  public var startupScript: String?
 
-  public init(name: String, type: WuhuEnvironmentType, path: String) {
+  public init(
+    name: String,
+    type: WuhuEnvironmentType,
+    path: String,
+    templatePath: String? = nil,
+    startupScript: String? = nil,
+  ) {
     self.name = name
     self.type = type
     self.path = path
+    self.templatePath = templatePath
+    self.startupScript = startupScript
   }
 }

--- a/Sources/WuhuAPI/WuhuRunnerProtocol.swift
+++ b/Sources/WuhuAPI/WuhuRunnerProtocol.swift
@@ -4,7 +4,7 @@ import PiAI
 public enum WuhuRunnerMessage: Sendable, Hashable, Codable {
   case hello(runnerName: String, version: Int)
 
-  case resolveEnvironmentRequest(id: String, name: String)
+  case resolveEnvironmentRequest(id: String, sessionID: String?, name: String)
   case resolveEnvironmentResponse(id: String, environment: WuhuEnvironment?, error: String?)
 
   case registerSession(sessionID: String, environment: WuhuEnvironment)
@@ -42,6 +42,7 @@ public enum WuhuRunnerMessage: Sendable, Hashable, Codable {
     case "resolve_environment_request":
       self = try .resolveEnvironmentRequest(
         id: c.decode(String.self, forKey: .id),
+        sessionID: c.decodeIfPresent(String.self, forKey: .sessionID),
         name: c.decode(String.self, forKey: .name),
       )
 
@@ -90,9 +91,10 @@ public enum WuhuRunnerMessage: Sendable, Hashable, Codable {
       try c.encode(runnerName, forKey: .runnerName)
       try c.encode(version, forKey: .version)
 
-    case let .resolveEnvironmentRequest(id, name):
+    case let .resolveEnvironmentRequest(id, sessionID, name):
       try c.encode("resolve_environment_request", forKey: .type)
       try c.encode(id, forKey: .id)
+      try c.encodeIfPresent(sessionID, forKey: .sessionID)
       try c.encode(name, forKey: .name)
 
     case let .resolveEnvironmentResponse(id, environment, error):

--- a/Sources/WuhuCore/SessionStore.swift
+++ b/Sources/WuhuCore/SessionStore.swift
@@ -20,6 +20,7 @@ public enum WuhuStoreError: Error, Sendable, CustomStringConvertible {
 
 public protocol SessionStore: Sendable {
   func createSession(
+    sessionID: String,
     provider: WuhuProvider,
     model: String,
     systemPrompt: String,

--- a/Sources/WuhuCore/WorkspaceManager.swift
+++ b/Sources/WuhuCore/WorkspaceManager.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+public enum WuhuWorkspaceError: Error, Sendable, CustomStringConvertible {
+  case invalidPath(String)
+  case templateNotFound(String)
+  case templateNotDirectory(String)
+  case failedToCopyTemplate(source: String, destination: String, underlying: String)
+  case startupScriptNotFound(String)
+  case startupScriptFailed(path: String, cwd: String, exitCode: Int32, output: String)
+
+  public var description: String {
+    switch self {
+    case let .invalidPath(path):
+      "Invalid path: \(path)"
+    case let .templateNotFound(path):
+      "Template folder not found: \(path)"
+    case let .templateNotDirectory(path):
+      "Template path is not a directory: \(path)"
+    case let .failedToCopyTemplate(source, destination, underlying):
+      "Failed to copy template folder: \(source) -> \(destination) (\(underlying))"
+    case let .startupScriptNotFound(path):
+      "Startup script not found: \(path)"
+    case let .startupScriptFailed(path, cwd, exitCode, output):
+      "Startup script failed (exit \(exitCode)) at \(path) (cwd=\(cwd)):\n\(output)"
+    }
+  }
+}
+
+public enum WuhuWorkspaceManager {
+  public static func defaultWorkspacesPath() -> String {
+    FileManager.default.homeDirectoryForCurrentUser
+      .appendingPathComponent(".wuhu/workspaces")
+      .path
+  }
+
+  public static func resolveWorkspacesPath(_ raw: String?, cwd: String = FileManager.default.currentDirectoryPath) -> String {
+    let trimmed = (raw ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty { return defaultWorkspacesPath() }
+    return ToolPath.resolveToCwd(trimmed, cwd: cwd)
+  }
+
+  /// Copies `templatePath` to a new workspace directory under `workspacesPath` and optionally executes `startupScript`.
+  ///
+  /// - `templatePath` is expected to be an absolute path (tilde-expanded).
+  /// - If `startupScript` is a relative path, it is resolved relative to the copied workspace root.
+  public static func materializeFolderTemplateWorkspace(
+    sessionID: String,
+    templatePath: String,
+    startupScript: String?,
+    workspacesPath: String,
+  ) async throws -> String {
+    let fm = FileManager.default
+
+    let expandedTemplate = ToolPath.expand(templatePath)
+    let expandedWorkspaces = ToolPath.expand(workspacesPath)
+
+    guard !expandedTemplate.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      throw WuhuWorkspaceError.invalidPath(templatePath)
+    }
+
+    var isDir: ObjCBool = false
+    guard fm.fileExists(atPath: expandedTemplate, isDirectory: &isDir) else {
+      throw WuhuWorkspaceError.templateNotFound(expandedTemplate)
+    }
+    guard isDir.boolValue else {
+      throw WuhuWorkspaceError.templateNotDirectory(expandedTemplate)
+    }
+
+    try fm.createDirectory(atPath: expandedWorkspaces, withIntermediateDirectories: true)
+
+    let destURL = uniqueWorkspaceURL(workspacesPath: expandedWorkspaces, baseName: sessionID)
+    do {
+      try fm.copyItem(at: URL(fileURLWithPath: expandedTemplate), to: destURL)
+    } catch {
+      throw WuhuWorkspaceError.failedToCopyTemplate(
+        source: expandedTemplate,
+        destination: destURL.path,
+        underlying: String(describing: error),
+      )
+    }
+
+    if let startupScript, !startupScript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      let scriptPath: String = {
+        let expanded = ToolPath.expand(startupScript)
+        if expanded.hasPrefix("/") { return expanded }
+        return destURL.appendingPathComponent(expanded).path
+      }()
+      guard fm.fileExists(atPath: scriptPath) else {
+        throw WuhuWorkspaceError.startupScriptNotFound(scriptPath)
+      }
+      try await runStartupScript(scriptPath: scriptPath, cwd: destURL.path)
+    }
+
+    return destURL.path
+  }
+
+  private static func uniqueWorkspaceURL(workspacesPath: String, baseName: String) -> URL {
+    let fm = FileManager.default
+    let root = URL(fileURLWithPath: workspacesPath)
+
+    let base = baseName.trimmingCharacters(in: .whitespacesAndNewlines)
+    let safeBase = base.isEmpty ? UUID().uuidString.lowercased() : base
+
+    var candidate = root.appendingPathComponent(safeBase, isDirectory: true)
+    if !fm.fileExists(atPath: candidate.path) { return candidate }
+
+    for i in 1 ... 999 {
+      candidate = root.appendingPathComponent("\(safeBase)-\(i)", isDirectory: true)
+      if !fm.fileExists(atPath: candidate.path) { return candidate }
+    }
+
+    return root.appendingPathComponent("\(safeBase)-\(UUID().uuidString.lowercased())", isDirectory: true)
+  }
+
+  private static func runStartupScript(scriptPath: String, cwd: String) async throws {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/bash")
+    process.arguments = ["-lc", "set -euo pipefail; bash \(shellEscape(scriptPath))"]
+    process.currentDirectoryURL = URL(fileURLWithPath: cwd)
+
+    let outputURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("wuhu-startup-\(UUID().uuidString.lowercased()).log")
+    FileManager.default.createFile(atPath: outputURL.path, contents: nil)
+    let outputHandle = try FileHandle(forWritingTo: outputURL)
+    process.standardOutput = outputHandle
+    process.standardError = outputHandle
+
+    try process.run()
+    process.waitUntilExit()
+    try? outputHandle.close()
+
+    let data = (try? Data(contentsOf: outputURL)) ?? Data()
+    let output = String(decoding: data, as: UTF8.self)
+    if process.terminationStatus != 0 {
+      throw WuhuWorkspaceError.startupScriptFailed(
+        path: scriptPath,
+        cwd: cwd,
+        exitCode: process.terminationStatus,
+        output: output,
+      )
+    }
+  }
+
+  private static func shellEscape(_ s: String) -> String {
+    if s.isEmpty { return "''" }
+    if s.range(of: #"[^A-Za-z0-9_\/\.\-]"#, options: .regularExpression) == nil { return s }
+    return "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
+  }
+}

--- a/Sources/WuhuCore/WuhuCore.docc/Design/FolderTemplateEnvironment.md
+++ b/Sources/WuhuCore/WuhuCore.docc/Design/FolderTemplateEnvironment.md
@@ -1,0 +1,62 @@
+# Folder Template Environments
+
+Wuhu supports an environment type named `folder-template` intended for **repeatable, pre-warmed workspaces**.
+
+Use cases:
+
+- A “multi-repo workspace” folder that includes multiple git repos plus an `AGENTS.md` describing how they relate.
+- Pre-cached build artifacts (`node_modules`, `.build`, etc.) to reduce setup time.
+- A startup script that refreshes repos or performs additional configuration in the copied workspace.
+
+## Configuration
+
+Both `server.yml` and `runner.yml` support:
+
+- `workspaces_path` (optional): where Wuhu creates per-session workspaces.
+  - Default: `~/.wuhu/workspaces`
+- `environments[].type: folder-template`
+- `environments[].path`: the template folder to copy from
+- `environments[].startup_script` (optional): a script path executed **in the copied workspace**
+
+Example:
+
+```yaml
+workspaces_path: ~/.wuhu/workspaces
+environments:
+  - name: multi-repo
+    type: folder-template
+    path: /Users/alice/Templates/multi-repo
+    startup_script: ./startup.sh
+```
+
+`startup_script` is resolved like this:
+
+- Absolute paths run as-is.
+- Relative paths are resolved relative to the copied workspace root.
+
+## Behavior
+
+At session creation time:
+
+1. Wuhu copies the template directory to `workspaces_path/<session-id>` (or `-N` if that path already exists).
+2. If `startup_script` is set, Wuhu executes it with `bash` in the copied workspace directory.
+3. The session’s working directory (`WuhuSession.cwd`) is the copied workspace path.
+
+For **runner sessions**, the runner performs the copy+startup and returns the resolved environment snapshot to the server.
+
+## Persistence
+
+Wuhu stores an immutable environment snapshot in both databases (server sessions DB and runner `runner_sessions` DB):
+
+- `environment.type = folder-template`
+- `environment.path = <copied workspace path>`
+- `environment.templatePath = <template folder path>`
+- `environment.startupScript = <startup_script value, if set>`
+
+This makes session execution reproducible even if config changes later.
+
+## Implementation Notes
+
+- The server includes `sessionID` in `resolve_environment_request` so a runner can create a session-specific workspace path.
+- SQLite migrations add columns for the extra environment metadata (`templatePath`, `startupScript`) without rewriting existing data.
+

--- a/Sources/WuhuCore/WuhuCore.docc/Design/ServerRunner.md
+++ b/Sources/WuhuCore/WuhuCore.docc/Design/ServerRunner.md
@@ -30,10 +30,15 @@ After this split, Wuhu supports:
 llm:
   openai: "…"
   anthropic: "…"
+workspaces_path: ~/.wuhu/workspaces
 environments:
   - name: wuhu-repo
     type: local
     path: /Users/selveskii/Developer/wuhu-swift
+  - name: multi-repo
+    type: folder-template
+    path: /Users/selveskii/Developer/wuhu-templates/multi-repo
+    startup_script: ./startup.sh
 runners:
   - name: vps-in-la
     address: 1.2.3.4:5531
@@ -48,10 +53,15 @@ listen:                        # used when connectTo is not set
   host: 0.0.0.0
   port: 5531
 databasePath: ~/.wuhu/runner.sqlite
+workspaces_path: ~/.wuhu/workspaces
 environments:
   - name: wuhu-repo
     type: local
     path: /home/ubuntu/wuhu-swift
+  - name: multi-repo
+    type: folder-template
+    path: /home/ubuntu/wuhu-templates/multi-repo
+    startup_script: ./startup.sh
 ```
 
 ### `client.yml` (optional)

--- a/Sources/WuhuCore/WuhuEnvironmentResolutionError.swift
+++ b/Sources/WuhuCore/WuhuEnvironmentResolutionError.swift
@@ -1,0 +1,16 @@
+public enum WuhuEnvironmentResolutionError: Error, Sendable, CustomStringConvertible {
+  case unknownEnvironment(String)
+  case unsupportedEnvironmentType(String)
+  case missingSessionIDForFolderTemplate
+
+  public var description: String {
+    switch self {
+    case let .unknownEnvironment(name):
+      "Unknown environment: \(name)"
+    case let .unsupportedEnvironmentType(type):
+      "Unsupported environment type: \(type)"
+    case .missingSessionIDForFolderTemplate:
+      "folder-template requires sessionID"
+    }
+  }
+}

--- a/Sources/WuhuCore/WuhuService.swift
+++ b/Sources/WuhuCore/WuhuService.swift
@@ -17,6 +17,7 @@ public actor WuhuService {
   }
 
   public func createSession(
+    sessionID: String,
     provider: WuhuProvider,
     model: String,
     systemPrompt: String,
@@ -25,6 +26,7 @@ public actor WuhuService {
     parentSessionID: String? = nil,
   ) async throws -> WuhuSession {
     try await store.createSession(
+      sessionID: sessionID,
       provider: provider,
       model: model,
       systemPrompt: systemPrompt,

--- a/Sources/WuhuRunner/WuhuRunnerConfig.swift
+++ b/Sources/WuhuRunner/WuhuRunnerConfig.swift
@@ -6,11 +6,20 @@ public struct WuhuRunnerConfig: Sendable, Hashable, Codable {
     public var name: String
     public var type: String
     public var path: String
+    public var startupScript: String?
 
-    public init(name: String, type: String, path: String) {
+    enum CodingKeys: String, CodingKey {
+      case name
+      case type
+      case path
+      case startupScript = "startup_script"
+    }
+
+    public init(name: String, type: String, path: String, startupScript: String? = nil) {
       self.name = name
       self.type = type
       self.path = path
+      self.startupScript = startupScript
     }
   }
 
@@ -28,6 +37,7 @@ public struct WuhuRunnerConfig: Sendable, Hashable, Codable {
   public var connectTo: String?
   public var listen: Listen?
   public var databasePath: String?
+  public var workspacesPath: String?
   public var environments: [Environment]
 
   public init(
@@ -35,13 +45,24 @@ public struct WuhuRunnerConfig: Sendable, Hashable, Codable {
     connectTo: String? = nil,
     listen: Listen? = nil,
     databasePath: String? = nil,
+    workspacesPath: String? = nil,
     environments: [Environment],
   ) {
     self.name = name
     self.connectTo = connectTo
     self.listen = listen
     self.databasePath = databasePath
+    self.workspacesPath = workspacesPath
     self.environments = environments
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case name
+    case connectTo
+    case listen
+    case databasePath
+    case workspacesPath = "workspaces_path"
+    case environments
   }
 
   public static func load(path: String) throws -> WuhuRunnerConfig {

--- a/Sources/WuhuServer/RunnerConnection.swift
+++ b/Sources/WuhuServer/RunnerConnection.swift
@@ -30,11 +30,11 @@ final actor RunnerConnection {
     failAllPending(error)
   }
 
-  func resolveEnvironment(name: String) async throws -> WuhuEnvironment {
+  func resolveEnvironment(sessionID: String, name: String) async throws -> WuhuEnvironment {
     let id = UUID().uuidString
     let response = try await requestResponse(
       requestId: id,
-      message: .resolveEnvironmentRequest(id: id, name: name),
+      message: .resolveEnvironmentRequest(id: id, sessionID: sessionID, name: name),
     )
     guard case let .resolveEnvironmentResponse(_, environment, error) = response else {
       throw PiAIError.decoding("Unexpected response")

--- a/Sources/WuhuServer/WuhuServerConfig.swift
+++ b/Sources/WuhuServer/WuhuServerConfig.swift
@@ -16,11 +16,20 @@ public struct WuhuServerConfig: Sendable, Hashable, Codable {
     public var name: String
     public var type: String
     public var path: String
+    public var startupScript: String?
 
-    public init(name: String, type: String, path: String) {
+    enum CodingKeys: String, CodingKey {
+      case name
+      case type
+      case path
+      case startupScript = "startup_script"
+    }
+
+    public init(name: String, type: String, path: String, startupScript: String? = nil) {
       self.name = name
       self.type = type
       self.path = path
+      self.startupScript = startupScript
     }
   }
 
@@ -39,6 +48,7 @@ public struct WuhuServerConfig: Sendable, Hashable, Codable {
   public var environments: [Environment]
   public var runners: [Runner]?
   public var databasePath: String?
+  public var workspacesPath: String?
   public var host: String?
   public var port: Int?
 
@@ -47,6 +57,7 @@ public struct WuhuServerConfig: Sendable, Hashable, Codable {
     environments: [Environment],
     runners: [Runner]? = nil,
     databasePath: String? = nil,
+    workspacesPath: String? = nil,
     host: String? = nil,
     port: Int? = nil,
   ) {
@@ -54,8 +65,19 @@ public struct WuhuServerConfig: Sendable, Hashable, Codable {
     self.environments = environments
     self.runners = runners
     self.databasePath = databasePath
+    self.workspacesPath = workspacesPath
     self.host = host
     self.port = port
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case llm
+    case environments
+    case runners
+    case databasePath
+    case workspacesPath = "workspaces_path"
+    case host
+    case port
   }
 
   public static func load(path: String) throws -> WuhuServerConfig {

--- a/Tests/WuhuCLITests/WuhuRunnerConfigTests.swift
+++ b/Tests/WuhuCLITests/WuhuRunnerConfigTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+import WuhuRunner
+
+struct WuhuRunnerConfigTests {
+  @Test func loadsYAMLWithWorkspacesAndStartupScript() throws {
+    let yaml = """
+    name: runner-1
+    connectTo: http://127.0.0.1:5530
+    workspaces_path: /tmp/wuhu-workspaces
+    databasePath: /tmp/runner.sqlite
+    environments:
+    - name: template
+      type: folder-template
+      path: /tmp/template
+      startup_script: ./startup.sh
+    """
+
+    let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("wuhu-runner-\(UUID().uuidString).yml")
+    try yaml.write(to: tmp, atomically: true, encoding: .utf8)
+    defer { try? FileManager.default.removeItem(at: tmp) }
+
+    let config = try WuhuRunnerConfig.load(path: tmp.path)
+    #expect(config.name == "runner-1")
+    #expect(config.connectTo == "http://127.0.0.1:5530")
+    #expect(config.workspacesPath == "/tmp/wuhu-workspaces")
+    #expect(config.databasePath == "/tmp/runner.sqlite")
+    #expect(config.environments.count == 1)
+    #expect(config.environments[0].name == "template")
+    #expect(config.environments[0].type == "folder-template")
+    #expect(config.environments[0].path == "/tmp/template")
+    #expect(config.environments[0].startupScript == "./startup.sh")
+  }
+}

--- a/Tests/WuhuCoreTests/AgentsContextTests.swift
+++ b/Tests/WuhuCoreTests/AgentsContextTests.swift
@@ -35,6 +35,7 @@ struct AgentsContextTests {
     let service = WuhuService(store: store)
 
     let session = try await service.createSession(
+      sessionID: UUID().uuidString.lowercased(),
       provider: .openai,
       model: "mock",
       systemPrompt: "Base prompt.",
@@ -111,6 +112,7 @@ struct AgentsContextTests {
     let service = WuhuService(store: store)
 
     let session = try await service.createSession(
+      sessionID: UUID().uuidString.lowercased(),
       provider: .openai,
       model: "mock",
       systemPrompt: "Base prompt.",

--- a/Tests/WuhuCoreTests/EnvironmentPersistenceTests.swift
+++ b/Tests/WuhuCoreTests/EnvironmentPersistenceTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+import WuhuCore
+
+struct EnvironmentPersistenceTests {
+  @Test func createSessionPersistsFolderTemplateMetadata() async throws {
+    let store = try SQLiteSessionStore(path: ":memory:")
+    let service = WuhuService(store: store)
+
+    let env = WuhuEnvironment(
+      name: "template-env",
+      type: .folderTemplate,
+      path: "/tmp/workspaces/sess-1",
+      templatePath: "/tmp/template",
+      startupScript: "startup.sh",
+    )
+
+    let sessionID = UUID().uuidString.lowercased()
+    _ = try await service.createSession(
+      sessionID: sessionID,
+      provider: .openai,
+      model: "mock",
+      systemPrompt: "You are helpful.",
+      environment: env,
+    )
+
+    let fetched = try await service.getSession(id: sessionID)
+    #expect(fetched.environment.type == .folderTemplate)
+    #expect(fetched.environment.path == "/tmp/workspaces/sess-1")
+    #expect(fetched.environment.templatePath == "/tmp/template")
+    #expect(fetched.environment.startupScript == "startup.sh")
+  }
+}

--- a/Tests/WuhuCoreTests/WorkspaceManagerTests.swift
+++ b/Tests/WuhuCoreTests/WorkspaceManagerTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+import WuhuCore
+
+struct WorkspaceManagerTests {
+  @Test func materializeFolderTemplateWorkspaceCopiesAndRunsStartupScript() async throws {
+    let fm = FileManager.default
+
+    let base = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("wuhu-workspace-tests-\(UUID().uuidString.lowercased())", isDirectory: true)
+    let template = base.appendingPathComponent("template", isDirectory: true)
+    let workspaces = base.appendingPathComponent("workspaces", isDirectory: true)
+
+    try fm.createDirectory(at: template, withIntermediateDirectories: true)
+
+    try "hello\n".write(to: template.appendingPathComponent("README.txt"), atomically: true, encoding: .utf8)
+
+    let script = """
+    echo started > started.txt
+    """
+    try script.write(to: template.appendingPathComponent("startup.sh"), atomically: true, encoding: .utf8)
+
+    defer { try? fm.removeItem(at: base) }
+
+    let workspacePath = try await WuhuWorkspaceManager.materializeFolderTemplateWorkspace(
+      sessionID: "sess-1",
+      templatePath: template.path,
+      startupScript: "startup.sh",
+      workspacesPath: workspaces.path,
+    )
+
+    #expect(workspacePath != template.path)
+    #expect(fm.fileExists(atPath: URL(fileURLWithPath: workspacePath).appendingPathComponent("README.txt").path))
+
+    let markerPath = URL(fileURLWithPath: workspacePath).appendingPathComponent("started.txt").path
+    #expect(fm.fileExists(atPath: markerPath))
+    #expect((try? String(contentsOfFile: markerPath, encoding: .utf8))?.trimmingCharacters(in: .whitespacesAndNewlines) == "started")
+  }
+}

--- a/Tests/WuhuCoreTests/WuhuCoreTests.swift
+++ b/Tests/WuhuCoreTests/WuhuCoreTests.swift
@@ -26,11 +26,16 @@ struct WuhuCoreTests {
     try await operation()
   }
 
+  private func newSessionID() -> String {
+    UUID().uuidString.lowercased()
+  }
+
   @Test func createSessionCreatesHeaderAndHeadTail() async throws {
     let store = try SQLiteSessionStore(path: ":memory:")
     let service = WuhuService(store: store)
 
     let session = try await service.createSession(
+      sessionID: newSessionID(),
       provider: .openai,
       model: "mock",
       systemPrompt: "You are helpful.",
@@ -58,6 +63,7 @@ struct WuhuCoreTests {
     let service = WuhuService(store: store)
 
     let session = try await service.createSession(
+      sessionID: newSessionID(),
       provider: .openai,
       model: "mock",
       systemPrompt: "You are a terminal agent.",
@@ -144,6 +150,7 @@ struct WuhuCoreTests {
             let service = WuhuService(store: store)
 
             let session = try await service.createSession(
+              sessionID: newSessionID(),
               provider: .openai,
               model: "mock",
               systemPrompt: "You are helpful.",
@@ -240,6 +247,7 @@ struct WuhuCoreTests {
     let service = WuhuService(store: store)
 
     let session = try await service.createSession(
+      sessionID: newSessionID(),
       provider: .openai,
       model: "mock",
       systemPrompt: "You are helpful.",
@@ -270,6 +278,7 @@ struct WuhuCoreTests {
     let service = WuhuService(store: store)
 
     let session = try await service.createSession(
+      sessionID: newSessionID(),
       provider: .openai,
       model: "mock",
       systemPrompt: "You are helpful.",
@@ -338,6 +347,7 @@ struct WuhuCoreTests {
     let service = WuhuService(store: store)
 
     let session = try await service.createSession(
+      sessionID: newSessionID(),
       provider: .openai,
       model: "mock",
       systemPrompt: "You are helpful.",
@@ -366,6 +376,7 @@ struct WuhuCoreTests {
     let service = WuhuService(store: store)
 
     let session = try await service.createSession(
+      sessionID: newSessionID(),
       provider: .openai,
       model: "mock",
       systemPrompt: "You are helpful.",

--- a/Tests/WuhuServerTests/WuhuRunnerProtocolTests.swift
+++ b/Tests/WuhuServerTests/WuhuRunnerProtocolTests.swift
@@ -11,7 +11,7 @@ struct WuhuRunnerProtocolTests {
 
     let messages: [WuhuRunnerMessage] = [
       .hello(runnerName: "vps-in-la", version: 1),
-      .resolveEnvironmentRequest(id: "req-1", name: "repo"),
+      .resolveEnvironmentRequest(id: "req-1", sessionID: "sess-1", name: "repo"),
       .resolveEnvironmentResponse(
         id: "req-1",
         environment: .init(name: "repo", type: .local, path: "/tmp/repo"),

--- a/Tests/WuhuServerTests/WuhuServerConfigTests.swift
+++ b/Tests/WuhuServerTests/WuhuServerConfigTests.swift
@@ -8,10 +8,12 @@ struct WuhuServerConfigTests {
     llm:
       openai: sk-openai
       anthropic: sk-anthropic
+    workspaces_path: /tmp/wuhu-workspaces
     environments:
     - name: wuhu-repo
       type: local
       path: /tmp/wuhu
+      startup_script: ./startup.sh
     databasePath: /tmp/wuhu.sqlite
     host: 127.0.0.1
     port: 5530
@@ -26,11 +28,13 @@ struct WuhuServerConfigTests {
     #expect(config.llm?.openai == "sk-openai")
     #expect(config.llm?.anthropic == "sk-anthropic")
     #expect(config.databasePath == "/tmp/wuhu.sqlite")
+    #expect(config.workspacesPath == "/tmp/wuhu-workspaces")
     #expect(config.host == "127.0.0.1")
     #expect(config.port == 5530)
     #expect(config.environments.count == 1)
     #expect(config.environments[0].name == "wuhu-repo")
     #expect(config.environments[0].type == "local")
     #expect(config.environments[0].path == "/tmp/wuhu")
+    #expect(config.environments[0].startupScript == "./startup.sh")
   }
 }


### PR DESCRIPTION
Closes #25.

- Add new environment type `folder-template` with `path` (template directory) and optional `startup_script`.
- Create per-session workspaces under `workspaces_path` (default `~/.wuhu/workspaces`) on both server and runner.
- Runner protocol now includes `sessionID` in `resolve_environment_request` so the runner can materialize a session-specific workspace.
- Persist folder-template metadata (`templatePath`, `startupScript`) via additive GRDB migrations (server + runner DBs).
- Docs + unit tests included.

Testing:
- `swift test`
- `swift package --allow-writing-to-package-directory swiftformat --lint .`
- Manual: ran local server+runner, created a runner session with a folder-template env, verified workspace copy + startup marker file.