### PR TITLE
Fix escaping closure in WuhuPerceptionTracking

### DIFF
--- a/WuhuApp/Sources/PerceptionTrackingCompat.swift
+++ b/WuhuApp/Sources/PerceptionTrackingCompat.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import SwiftUI
 
 @ViewBuilder
-func WuhuPerceptionTracking<Content: View>(@ViewBuilder _ content: @escaping () -> Content) -> some View {
+func WuhuPerceptionTracking(@ViewBuilder _ content: @escaping () -> some View) -> some View {
   #if os(macOS)
     content()
   #else


### PR DESCRIPTION
Fixes build error in `WuhuApp/Sources/PerceptionTrackingCompat.swift` where an escaping closure (passed to `WithPerceptionTracking`) captured the non-escaping `content` parameter.

Validation:
- `xcodebuild -skipMacroValidation -skipPackagePluginValidation -project WuhuApp/WuhuApp.xcodeproj -scheme WuhuApp -configuration Release -destination "generic/platform=iOS" -archivePath /tmp/WuhuApp.xcarchive archive CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=`
