### PR TITLE
Fix follow SSE streaming regression after WUHU-0009

### DIFF
--- a/Tests/PiAITests/SSEDecoderTests.swift
+++ b/Tests/PiAITests/SSEDecoderTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import PiAI
+import Testing
+
+struct SSEDecoderTests {
+  @Test func decodeDropsTrailingPartialFrame() async throws {
+    let partial = Data(#"data: {"type":"assistant_text_delta","delta":"Hi""#.utf8)
+    let stream = SSEDecoder.decode(partial)
+
+    var messages: [SSEMessage] = []
+    for try await message in stream {
+      messages.append(message)
+    }
+
+    #expect(messages.isEmpty)
+  }
+
+  @Test func decodeYieldsCompleteFrame() async throws {
+    let frame = Data("data: {\"type\":\"done\"}\n\n".utf8)
+    let stream = SSEDecoder.decode(frame)
+
+    var messages: [SSEMessage] = []
+    for try await message in stream {
+      messages.append(message)
+    }
+
+    #expect(messages == [SSEMessage(event: nil, data: #"{"type":"done"}"#)])
+  }
+
+  @Test func decodeSkipsDONEFrames() async throws {
+    let data = Data("data: [DONE]\n\n".utf8)
+    let stream = SSEDecoder.decode(data)
+
+    var messages: [SSEMessage] = []
+    for try await message in stream {
+      messages.append(message)
+    }
+
+    #expect(messages.isEmpty)
+  }
+}


### PR DESCRIPTION
WUHU-0009 / PR #48 switched clients to use the long-lived `follow` SSE stream.

This fixes the iOS-visible regression ("Decoding error: stream ended at an unexpected time") by:
- Using a long SSE request timeout (24h) instead of the default 300s request timeout.
- Treating cancellation/EOF mid-frame as a graceful termination (drop trailing partial frames; don't wrap transport errors as decoding errors).

Adds `SSEDecoderTests` to cover partial-frame dropping behavior.