### PR TITLE
Fix subscription hub dict copy and SSE encode crash

### DIFF
--- a/Sources/WuhuCore/WuhuSessionSubscriptionHub.swift
+++ b/Sources/WuhuCore/WuhuSessionSubscriptionHub.swift
@@ -17,12 +17,10 @@ actor WuhuSessionSubscriptionHub {
   }
 
   func publish(sessionID: String, event: SessionEvent) {
-    guard var sessionSubs = subscribers[sessionID], !sessionSubs.isEmpty else { return }
-    for (token, continuation) in sessionSubs {
+    guard let sessionSubs = subscribers[sessionID], !sessionSubs.isEmpty else { return }
+    for (_, continuation) in sessionSubs {
       continuation.yield(event)
-      sessionSubs[token] = continuation
     }
-    subscribers[sessionID] = sessionSubs
   }
 
   private func removeSubscriber(sessionID: String, token: UUID) {


### PR DESCRIPTION
## Summary
- Remove unnecessary copy-on-write dance in `WuhuSessionSubscriptionHub.publish` — the dictionary value was being copied, mutated, and written back for no reason
- Change `try!` to `try?` with graceful bail in `WuhuServer`'s SSE `yieldFrame` to prevent a crash if a `SessionEvent` ever fails to encode

## Test plan
- [x] `swift test` passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)