### PR TITLE
Replace WuhuWorkspaceDocsStore with wuhu-workspace-engine

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,6 +31,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/wuhu-labs/wuhu-ai.git", from: "0.1.0"),
+    .package(url: "https://github.com/wuhu-labs/wuhu-workspace-engine.git", from: "0.1.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
     .package(url: "https://github.com/swiftlang/swift-testing.git", revision: "48a471ab313e858258ab0b9b0bf2cea55a50cefb"),
     .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
@@ -89,6 +90,8 @@ let package = Package(
         .product(name: "HummingbirdWebSocket", package: "hummingbird-websocket"),
         .product(name: "HummingbirdWSClient", package: "hummingbird-websocket"),
         .product(name: "Yams", package: "Yams"),
+        .product(name: "WorkspaceEngine", package: "wuhu-workspace-engine"),
+        .product(name: "WorkspaceScanner", package: "wuhu-workspace-engine"),
       ],
       swiftSettings: strictConcurrency,
     ),


### PR DESCRIPTION
## Summary

Replace the hand-rolled `WuhuWorkspaceDocsStore` (manual `FileManager.enumerator` + Yams frontmatter parsing) with `wuhu-workspace-engine` 0.1.0, which provides:

- **WorkspaceScanner** — file discovery, YAML frontmatter parsing, and FSEvents-based live watching
- **WorkspaceEngine** — in-memory SQLite-backed document storage with GRDB observation

### Changes

**Package.swift**
- Added `wuhu-workspace-engine` 0.1.0 dependency
- Added `WorkspaceEngine` and `WorkspaceScanner` products to WuhuServer target

**WuhuWorkspaceDocsStore.swift** — rewritten to wrap the engine:
- `init` creates a `WorkspaceScanner` and `WorkspaceEngine` (configured from `wuhu.yml`)
- `startWatching()` launches the FSEvents watcher in a background task for live sync
- `listDocs()` delegates to `engine.allDocuments()` and converts to `[WuhuWorkspaceDocSummary]`
- `readDoc()` uses `engine.document(at:)` for metadata + reads body from disk (engine intentionally omits bodies)
- `ensureDefaultDirectories()` now also creates a default `wuhu.yml` with path-based rules (`issues/**` → `kind: issue`)
- Removed `import Yams` — engine handles YAML parsing internally
- Kept path sanitization and traversal protection

**WuhuServer.swift**
- Store creation is now `try` (engine init can throw)
- Added `workspaceDocsStore.startWatching()` at startup
- Routes now use `await` (engine queries are async)

**Tests** — updated to async engine-backed API:
- Tests manually call `scanner.scan(into: engine)` to populate the engine before querying
- Removed test assertion for YAML array values (engine stores properties as flat `[String: String]`)
- Added assertion for `kind` in frontmatter (now always present via engine)
- Path traversal rejection test unchanged

### What's unchanged
- `WuhuWorkspaceDocSummary` and `WuhuWorkspaceDoc` wire types (WuhuAPI)
- API routes (`GET /v1/workspace/docs`, `GET /v1/workspace/doc`)
- WuhuClient methods
- WuhuApp code

### Verification
- `swift build` ✅
- `swift test` — all 97 tests pass ✅